### PR TITLE
Add include-branch-in-cache-key parameter

### DIFF
--- a/src/commands/with-cache.yml
+++ b/src/commands/with-cache.yml
@@ -46,7 +46,7 @@ parameters:
     type: boolean
     default: true
     description: >
-      If true, includes current branch name to cache key
+      If true, includes current branch name in cache key
 
 steps:
   - restore_cache:

--- a/src/commands/with-cache.yml
+++ b/src/commands/with-cache.yml
@@ -51,8 +51,8 @@ parameters:
 steps:
   - restore_cache:
       keys:
-        - node-deps-<<parameters.cache-version>>-<<^parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<<parameters.cache-key>>" }}
-        - <<^parameters.use-strict-cache>>node-deps-<<parameters.cache-version>><<^parameters.include-branch-in-cache-key>>-{{ .Branch }}<</parameters.include-branch-in-cache-key>><</parameters.use-strict-cache>>
+        - node-deps-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<<parameters.cache-key>>" }}
+        - <<^parameters.use-strict-cache>>node-deps-<<parameters.cache-version>><<#parameters.include-branch-in-cache-key>>-{{ .Branch }}<</parameters.include-branch-in-cache-key>><</parameters.use-strict-cache>>
         - <<^parameters.use-strict-cache>>node-deps-<<parameters.cache-version>><</parameters.use-strict-cache>>
 
   - steps: <<parameters.steps>>

--- a/src/commands/with-cache.yml
+++ b/src/commands/with-cache.yml
@@ -42,11 +42,17 @@ parameters:
     description: >
       If true, ignores non-checksum cache hits
 
+  include-branch-in-cache-key:
+    type: boolean
+    default: true
+    description: >
+      If true, includes current branch name to cache key
+
 steps:
   - restore_cache:
       keys:
-        - node-deps-<<parameters.cache-version>>-{{ .Branch }}-{{ checksum "<<parameters.cache-key>>" }}
-        - <<^parameters.use-strict-cache>>node-deps-<<parameters.cache-version>>-{{ .Branch }}-<</parameters.use-strict-cache>>
+        - node-deps-<<parameters.cache-version>>-<<^parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<<parameters.cache-key>>" }}
+        - <<^parameters.use-strict-cache>>node-deps-<<parameters.cache-version>><<^parameters.include-branch-in-cache-key>>-{{ .Branch }}<</parameters.include-branch-in-cache-key>><</parameters.use-strict-cache>>
         - <<^parameters.use-strict-cache>>node-deps-<<parameters.cache-version>><</parameters.use-strict-cache>>
 
   - steps: <<parameters.steps>>


### PR DESCRIPTION
If true, includes current branch name to cache key

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

Sometimes we might need to not include branch name in the cache key. So a config available for that will be helpful.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

There can be cases where users won't want to include the branch name in the cache key. Currently since cache key always has branch name there is no way this orb can be used for such case. So a new boolean parameter based on which branch name is added to cache key is introduced. By default its values is true so that the current behaviour is preserved.