### PR TITLE
fix include-branch-in-cache-key parameter bug

### DIFF
--- a/src/commands/with-cache.yml
+++ b/src/commands/with-cache.yml
@@ -58,6 +58,6 @@ steps:
   - steps: <<parameters.steps>>
 
   - save_cache:
-      key: node-deps-<<parameters.cache-version>>-{{ .Branch }}-{{ checksum "<<parameters.cache-key>>" }}
+      key: node-deps-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<<parameters.cache-key>>" }}
       paths:
         - <<parameters.dir>>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->
Fix a bug with include-branch-in-cache-key parameter 

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
include-branch-in-cache-key parameter is not saving cache as branch is included in save_cache step
