### PR TITLE
Add quickstart jobs with examples

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -3,3 +3,84 @@ version: 2.1
 description: >
   Simplify common tasks for building and testing Node projects.
   Source: https://github.com/circleci-public/node-orb
+
+examples:
+  quickstart-tests:
+    description: >
+      A simple install dependencies and test job that relies on npm conventions
+      and will cache dependencies between builds.
+    usage:
+      version: 2.1
+      orbs:
+        node: circleci/node@x.y.z
+      workflows:
+        build:
+          jobs:
+            - node/test
+
+  quickstart-running-commands:
+    description: >
+      If you want to run a different command after installing dependencies
+      you can do that too.
+    usage:
+      version: 2.1
+      orbs:
+        node: circleci/node@x.y.z
+      workflows:
+        build:
+          jobs:
+            - node/run:
+                tag: lts
+                command: npm run generate-docs
+
+  installing-dependencies:
+    description: >
+      You can also use the dependency install and caching commands directly in
+      your own jobs.
+    usage:
+      version: 2.1
+      orbs:
+        node: circleci/node@x.y.z
+      job:
+        build:
+          - run: echo "Install dependencies using 'npm ci' with a cache"
+          - node/npm-ci
+
+          - run: echo "Or use different commands with the cache"
+          - node/with-cache:
+              cache-key: yarn.lock
+              steps:
+                - run: yarn install --frozen-lockfile
+
+  quickstart-tests-with-results:
+    description: >
+      If your test runner is configured to produce Junit XML, we can save and
+      parse the details of failed tests to display in the UI.
+    usage:
+      version: 2.1
+      orbs:
+        node: circleci/node@x.y.z
+      workflows:
+        build:
+          jobs:
+            - node/test:
+                tag: lts
+                test-results-path: /tmp/test-results
+
+  quickstart-tests-with-lint-and-codecov:
+    description: >
+      You can also specify extra commands to run before or after tests.
+    usage:
+      version: 2.1
+      orbs:
+        node: circleci/node@x.y.z
+        codecov: codecov/codecov@1.0.5
+      workflows:
+        build:
+          jobs:
+            - node/test:
+                tag: lts
+                before-tests:
+                  - run: npm run lint
+                after-tests:
+                  - codecov/upload

--- a/src/commands/npm-ci.yml
+++ b/src/commands/npm-ci.yml
@@ -1,0 +1,36 @@
+description: >
+  Install your dependencies using `npm ci`
+
+parameters:
+  cache-dir:
+    type: string
+    default: ~/.npm
+    description: >
+      Path to the npm package cache
+
+  cache-version:
+    type: string
+    default: v1
+    description: >
+      Cache version; increment this for a fresh cache
+
+  use-strict-cache:
+    type: boolean
+    default: false
+    description: >
+      If true, ignores non-checksum cache hits
+
+  include-branch-in-cache-key:
+    type: boolean
+    default: true
+    description: >
+      If true, includes current branch name in cache key
+
+steps:
+  - with-cache:
+      dir: <<parameters.cache-dir>>
+      cache-version: <<parameters.cache-version>>
+      use-strict-cache: <<parameters.use-strict-cache>>
+      include-branch-in-cache-key: <<parameters.include-branch-in-cache-key>>
+      steps:
+        - run: npm ci

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -1,0 +1,32 @@
+description: |
+  Install npm dependencies then run some commands
+
+parameters:
+  tag:
+    type: string
+    default: "latest"
+    description: >
+      Pick a specific circleci/node image variant:
+      https://hub.docker.com/r/circleci/node/tags
+  command:
+    type: string
+    default: ""
+    description: Run a single command
+  steps:
+    type: steps
+    default: []
+    description: >
+      Run a series of steps
+
+executor:
+  name: default
+  tag: << parameters.tag >>
+
+steps:
+  - checkout
+  - npm-ci
+  - when:
+      condition: << parameters.command >>
+      steps:
+        - run: << parameters.command >>
+  - steps: << parameters.steps >>

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -1,0 +1,48 @@
+description: |
+  Install npm dependencies then run tests
+
+parameters:
+  tag:
+    type: string
+    default: "latest"
+    description: >
+      Pick a specific circleci/node image variant:
+      https://hub.docker.com/r/circleci/node/tags
+  test-command:
+    type: string
+    default: "npm test"
+    description: >
+      The command to be used for running tests
+  test-results-path:
+    type: string
+    default: ""
+    description: >
+      Folder container junit test results files to be saved
+  before-tests:
+    type: steps
+    default: []
+    description: >
+      Run extra steps before the tests
+  after-tests:
+    type: steps
+    default: []
+    description: >
+      Run extra steps after the tests
+
+executor:
+  name: default
+  tag: << parameters.tag >>
+
+steps:
+  - checkout
+  - npm-ci
+  - steps: << parameters.before-tests >>
+  - run: << parameters.test-command >>
+  - steps: << parameters.after-tests >>
+  - when:
+      condition: << parameters.test-results-path >>
+      steps:
+        - store_artifacts:
+            path: << parameters.test-results-path >>
+        - store_test_results:
+            path: << parameters.test-results-path >>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

This was prompted by a conversation in slack, about how easy we could make onboarding a new NodeJS project.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

* Adds `npm-ci`, which installs dependencies in the [way npm recommends for CI](https://docs.npmjs.com/cli/ci)
* Adds `run` job, which does checkout, dependencies, then runs whatever you tell it to
* Adds `test` job, which does checkout, dependencies, then runs your tests
