### PR TITLE
Support x.yy Alpine version numbers in install-npm.yml

### DIFF
--- a/src/commands/install-npm.yml
+++ b/src/commands/install-npm.yml
@@ -51,7 +51,7 @@ steps:
 
         if cat /etc/issue<<^parameters.debug>> 2> /dev/null<</parameters.debug>> | grep Alpine<<^parameters.debug>> > /dev/null 2>&1<</parameters.debug>>; then
           # https://wiki.alpinelinux.org/wiki/Include:Upgrading_to_Edge
-          sed -i -e 's/v[[:digit:]]\.[[:digit:]]/edge/g' /etc/apk/repositories
+          sed -i -e 's/v[[:digit:]]\.[[:digit:]][[:digit:]]?/edge/g' /etc/apk/repositories
           apk upgrade --update-cache --available<<^parameters.debug>> > /dev/null 2>&1<</parameters.debug>>
 
           apk --no-cache add npm<<^parameters.debug>> > /dev/null 2>&1<</parameters.debug>>

--- a/src/commands/install-npm.yml
+++ b/src/commands/install-npm.yml
@@ -51,7 +51,7 @@ steps:
 
         if cat /etc/issue<<^parameters.debug>> 2> /dev/null<</parameters.debug>> | grep Alpine<<^parameters.debug>> > /dev/null 2>&1<</parameters.debug>>; then
           # https://wiki.alpinelinux.org/wiki/Include:Upgrading_to_Edge
-          sed -i -e 's/v[[:digit:]]\.[[:digit:]][[:digit:]]?/edge/g' /etc/apk/repositories
+          sed -i -e 's/v[[:digit:]]\.[[:digit:]]\+/edge/g' /etc/apk/repositories
           apk upgrade --update-cache --available<<^parameters.debug>> > /dev/null 2>&1<</parameters.debug>>
 
           apk --no-cache add npm<<^parameters.debug>> > /dev/null 2>&1<</parameters.debug>>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

The latest version of Alpine Linux is v3.10: https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases

However, the regexp used in the `sed` command in `install-npm.yml` only supports single digit minor versions, e.g. it supports 3.9 but not 3.10.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

This change updates the regexp used so that is also supports minor versions which are more than just one digit long.