### PR TITLE
Add with-cache example to the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,25 @@ An orb for working with Node.js on CircleCI.
 
 ## Usage
 
+A quick example of using `with-cache`:
+
+```yaml
+version: 2.1
+orbs:
+  node: circleci/node@1.1.4
+jobs:
+  build:
+    docker:
+      - image: circleci/node:12.7
+    working_directory: ~/project
+    steps:
+      - checkout
+      - node/with-cache:
+          steps:
+            - run: npm install
+      - run: npm run test
+```
+
 For full usage guidelines, see the [orb registry listing](http://circleci.com/orbs/registry/orb/circleci/node).
 
 ## Contributing


### PR DESCRIPTION
Per issue #2 the documentation both here and in the org registry listing is pretty bad.

I.e. it took ~30 minutes of failed builds + googling just to get ^ which is essentially the orb-version of the "getting started with node" snippet from the "set up job" flow.

Granted, the orb registry has detailed documentation of the step definitions, but no concrete examples that show things like the `node/` prefix being required for orb-defined commands.

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
