### PR TITLE
docs: update yarn example to use a string value

### DIFF
--- a/src/examples/yarn.yml
+++ b/src/examples/yarn.yml
@@ -5,9 +5,7 @@ usage:
     node: circleci/node@1.1
   jobs:
     build:
-      executor:
-        name: node/default
-        tag: "10.4"
+      executor: node/default@10.4
       steps:
         - checkout
         - node/with-cache:


### PR DESCRIPTION
When using this example, a type warning is raised that the expected value for an `executor` is a string.
