### PR TITLE
Error if no package.json file. [semver:patch]

### DIFF
--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -45,7 +45,7 @@ steps:
       name: Installing Node Modules.
       working_directory: <<parameters.app-dir>>
       command: |
-        if [ ! -f "<<parameters.app-dir>>/package.json" ]; then
+        if [ ! -f "package.json" ]; then
           echo
           echo "---"
           echo "Unable to find your package.json file. Did you forget to set the app-dir parameter?"

--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -45,6 +45,20 @@ steps:
       name: Installing Node Modules.
       working_directory: <<parameters.app-dir>>
       command: |
+        if [ ! -f "<<parameters.app-dir>>/package.json" ]; then
+          echo
+          echo "---"
+          echo "Unable to find your package.json file. Did you forget to set the app-dir parameter?"
+          echo "---"
+          echo
+          echo "Current directory: $(pwd)"
+          echo
+          echo
+          echo "List directory: "
+          echo
+          ls
+          exit 1
+        fi
         case << parameters.pkg-manager >> in
           npm)
             if [[ << parameters.override-ci >> ]]; then


### PR DESCRIPTION
Provide an exit 1 if no package.json is found.

Currently, a warning will be given but no error: https://app.circleci.com/pipelines/github/CircleCI-Public/serverless-framework-orb/82/workflows/2246dd64-714c-43b9-a339-a3c86a4009f1/jobs/219