### PR TITLE
Improving fetching of node versions [semver:minor]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   node: circleci/node@<<pipeline.parameters.dev-orb-version>>
-  orb-tools: circleci/orb-tools@9.0
+  orb-tools: circleci/orb-tools@9.1
 
 # Pipeline parameters
 parameters:
@@ -17,11 +17,19 @@ parameters:
 
 integration-tests: &integration-tests
   [
-    integration-test-install-linux,
-    integration-test-install-mac,
+    integration-test-install-specified-version,
+    integration-test-install-lts
     node-test-job,
-    integration-test-install-linux-latest
+    integration-test-install-latest
   ]
+
+executors:
+  linux:
+    docker:
+      - image: cimg/base:stable
+  macos:
+    macos:
+      xcode: 11.4
 
 commands:
   install-nvm:
@@ -36,9 +44,11 @@ commands:
 
 jobs:
 # Install NodeJS into a non-node container.
-  integration-test-install-linux:
-    docker:
-      - image: cimg/base:stable
+  integration-test-install-specified-version:
+    parameters:
+      os:
+        type: executor
+    executor: <<parameters.os>>
     steps:
       - checkout
       - node/install:
@@ -51,9 +61,11 @@ jobs:
               exit 1
             fi
 
-  integration-test-install-linux-latest:
-    docker:
-      - image: cimg/base:stable
+  integration-test-install-latest:
+    parameters:
+      os:
+        type: executor
+    executor: <<parameters.os>>
     steps:
       - checkout
       - node/install:
@@ -70,9 +82,11 @@ jobs:
               exit 1
             fi
 
-  integration-test-install-linux-lts:
-    docker:
-      - image: cimg/base:stable
+  integration-test-install-lts:
+    parameters:
+      os:
+        type: executor
+    executor: <<parameters.os>>
     steps:
       - checkout
       - node/install:
@@ -89,20 +103,6 @@ jobs:
               exit 1
             fi
 
-  integration-test-install-mac:
-    macos:
-      xcode: 11.4.0
-    steps:
-      - checkout
-      - node/install:
-          node-version: "13.11.0"
-          install-yarn: true # Test the install of YARN
-      - run:
-          command: |
-            if ! node --version | grep -q "13"; then
-              echo "Node version 13 not found"
-            fi
-
 
 workflows:
   # This `lint-pack_validate_publish-dev` workflow will run on any commit.
@@ -114,6 +114,12 @@ workflows:
       # validate the orb.yml file to ensure it is well-formed
       - orb-tools/pack
 
+      - approve_for_testing:
+          type: approval
+          requires:
+            - orb-tools/pack
+            - orb-tools/lint
+
       # release dev version of orb, for testing & possible publishing.
       # orb will be published as dev:alpha and dev:${CIRCLE_SHA1:0:7}.
       # requires a CircleCI API token to be stored as CIRCLE_TOKEN (default)
@@ -124,8 +130,7 @@ workflows:
           orb-name: circleci/node
           context: orb-publishing
           requires:
-            - orb-tools/pack
-            - orb-tools/lint
+            - approve_for_testing
 
       # trigger an integration workflow to test the
       # dev:${CIRCLE_SHA1:0:7} version of your orb
@@ -145,10 +150,18 @@ workflows:
       # your integration test jobs go here: essentially, run all your orb's
       # jobs and commands to ensure they behave as expected. or, run other
       # integration tests of your choosing
-      - integration-test-install-linux
-      - integration-test-install-mac
-      - integration-test-install-linux-latest
-      - integration-test-install-linux-lts
+      - integration-test-install-specified-version:
+          matrix:
+            parameters:
+              os: [linux, macos]
+      - integration-test-install-latest:
+          matrix:
+            parameters:
+              os: [linux, macos]
+      - integration-test-install-lts:
+          matrix:
+            parameters:
+              os: [linux, macos]
       - node/test:
           name: node-test-job
           app-dir: "~/project/sample"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,17 @@ integration-tests: &integration-tests
     integration-test-install-linux-latest
   ]
 
+commands:
+  install-nvm:
+    steps:
+      - run:
+          name: Install nvm
+          command: |
+            curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
+            NVM_DIR="$HOME/.nvm"
+            echo "export NVM_DIR=\"$HOME/.nvm\"" >> $BASH_ENV
+            echo "[ -s \"$NVM_DIR/nvm.sh\" ] && \. \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
+
 jobs:
 # Install NodeJS into a non-node container.
   integration-test-install-linux:
@@ -47,14 +58,34 @@ jobs:
       - checkout
       - node/install:
           node-version: "latest"
+      - install-nvm
       - run:
           name: Check that latest NodeJS is installed.
           command: |
-            NODE_ORB_INSTALL_VERSION=$(curl -Ls -o /dev/null -w %{url_effective} \
-              "https://github.com/nodejs/node/releases/latest" | sed 's:.*/::' | cut -d 'v' -f 2)
+            NODE_ORB_INSTALL_VERSION=$(nvm ls-remote | tail -n1 | awk '{print $1}')
+            echo "Latest Node version = $NODE_ORB_INSTALL_VERSION"
+            echo "Installed version: $(node --version)"
             if ! node --version | grep -q "$NODE_ORB_INSTALL_VERSION"; then
-              echo "Latest Node version = $NODE_ORB_INSTALL_VERSION"
-              echo "Installed version: $(node --version)"
+              echo "Error: Installed version is different from the latest version."
+              exit 1
+            fi
+
+  integration-test-install-linux-lts:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - node/install:
+          node-version: "lts"
+      - install-nvm
+      - run:
+          name: Check that the latest LTS version of NodeJS is installed.
+          command: |
+            NODE_ORB_INSTALL_VERSION=$(nvm ls-remote | grep 'Latest LTS' | tail -n1 | awk '{print $1}')
+            echo "Latest Node LTS version = $NODE_ORB_INSTALL_VERSION"
+            echo "Installed version: $(node --version)"
+            if ! node --version | grep -q "$NODE_ORB_INSTALL_VERSION"; then
+              echo "Error: Installed version is different from the latest LTS version."
               exit 1
             fi
 
@@ -117,6 +148,7 @@ workflows:
       - integration-test-install-linux
       - integration-test-install-mac
       - integration-test-install-linux-latest
+      - integration-test-install-linux-lts
       - node/test:
           name: node-test-job
           app-dir: "~/project/sample"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ parameters:
 integration-tests: &integration-tests
   [
     integration-test-install-specified-version,
-    integration-test-install-lts
+    integration-test-install-lts,
     node-test-job,
     integration-test-install-latest
   ]

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -71,7 +71,7 @@ steps:
             echo "Latest version of Node.js is $NODE_ORB_INSTALL_VERSION"
           elif [[ <<parameters.node-version>> == "lts" || <<parameters.node-version>> == "stable" ]]; then
             # Codename is last field, first one with a name is newest lts
-            NODE_ORB_INSTALL_VERSION=$(get_node_index | grep -E "\t[a-zA-Z]+\$" | awk "NR<=1" | cut -f 1 | grep -E -o '[^v].*')
+            NODE_ORB_INSTALL_VERSION=$(get_node_index | grep -E "[[:space:]][a-zA-Z]+\$" | awk "NR<=1" | cut -f 1 | grep -E -o '[^v].*')
             echo "Latest LTS version of Node.js is $NODE_ORB_INSTALL_VERSION"
           else
             NODE_ORB_INSTALL_VERSION="<<parameters.node-version>>"

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -9,7 +9,8 @@ parameters:
     type: string
     default: ''
     description: >
-      The latest (current) version of NodeJS will be installed unless a version is specified. A full version tag must be specified. Example: "13.11.0"
+      You may specify a full version tag ("13.11.0"), "latest", "current", "lts", or "stable".
+      The latest (current) version of NodeJS will be installed by default.
       For a full list of releases, see the following: https://nodejs.org/en/download/releases
 
   node-install-dir:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -7,7 +7,7 @@ parameters:
   # node
   node-version:
     type: string
-    default: ""
+    default: ''
     description: >
       The latest (current) version of NodeJS will be installed unless a version is specified. A full version tag must be specified. Example: "13.11.0"
       For a full list of releases, see the following: https://nodejs.org/en/download/releases
@@ -39,7 +39,7 @@ parameters:
 
   yarn-version:
     type: string
-    default: ""
+    default: ''
     description: >
       Pick a version of Yarn to install (if no version is specified,
       the latest stable version will be installed):
@@ -60,11 +60,18 @@ steps:
 
         # FUNCTIONS
 
+        get_node_index () {
+          curl -Ls 'https://nodejs.org/dist/index.tab' | tail -n +2 | cut -f 1,3,10
+        }
+
         get_node_version () {
           if [[ <<parameters.node-version>> == "" || <<parameters.node-version>> == "latest" || <<parameters.node-version>> == "current" ]]; then
-            NODE_ORB_INSTALL_VERSION=$(curl -Ls -o /dev/null -w %{url_effective} \
-              "https://github.com/nodejs/node/releases/latest" | sed 's:.*/::' | cut -d 'v' -f 2)
+            NODE_ORB_INSTALL_VERSION=$(get_node_index | awk "NR<=1" | cut -f 1 | grep -E -o '[^v].*')
             echo "Latest version of Node.js is $NODE_ORB_INSTALL_VERSION"
+          elif [[ <<parameters.node-version>> == "lts" || <<parameters.node-version>> == "stable" ]]; then
+            # Codename is last field, first one with a name is newest lts
+            NODE_ORB_INSTALL_VERSION=$(get_node_index | grep -E "\t[a-zA-Z]+\$" | awk "NR<=1" | cut -f 1 | grep -E -o '[^v].*')
+            echo "Latest LTS version of Node.js is $NODE_ORB_INSTALL_VERSION"
           else
             NODE_ORB_INSTALL_VERSION="<<parameters.node-version>>"
             echo "Selected version of Node.js is $NODE_ORB_INSTALL_VERSION"


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [X] All new jobs, commands, executors, parameters have descriptions
- [X] Examples have been added for any significant new features
- [X] README has been updated, if necessary

### Motivation, issues

- Fixes a bug fetching the  "latest" node version that could cause build failures.
- Most users will want the "lts" or "stable" version

### Description

- The current method of getting the latest Node.js is incorrect. The "latest" version currently fetched is the most recently updated, which is incorrect. At the time of this commit, the "latest" version on GitHub is 10.20.1, well behind the latest.
- Adds support for "lts" and "stable" as node-version parameters

This new method is based on tj/n's method of fetching versions:
https://github.com/tj/n/blob/8c55fba3d504a69e79946dfef1ad242c67f27552/bin/n#L960-L1019

tj/n references Node's own dist-indexer as a source:
https://github.com/nodejs/nodejs-dist-indexer/blob/master/dist-indexer.js