### PR TITLE
Fix syntax error in example code

### DIFF
--- a/src/examples/run_tests_with_npm.yml
+++ b/src/examples/run_tests_with_npm.yml
@@ -12,7 +12,7 @@ usage:
       steps:
         - checkout
         - node/install-packages
-        - npm run test
+        - run: npm run test
   workflows:
     test_my_app:
       jobs:


### PR DESCRIPTION
added missing `run: ` to test command.

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
