### PR TITLE
fix: use string comparison in bash code for "boolean" [semver:patch]

### DIFF
--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -68,7 +68,7 @@ steps:
             fi
           ;;
           yarn)
-            if [[ "<< parameters.override-ci >> == "true" ]]; then
+            if [[ "<< parameters.override-ci >>" == "true" ]]; then
               yarn install
             else
               yarn install --frozen-lockfile

--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -61,14 +61,14 @@ steps:
         fi
         case << parameters.pkg-manager >> in
           npm)
-            if [[ << parameters.override-ci >> ]]; then
+            if [[ "<< parameters.override-ci >>" == "true" ]]; then
               npm install
             else
               npm ci
             fi
           ;;
           yarn)
-            if [[ << parameters.override-ci >> ]]; then
+            if [[ "<< parameters.override-ci >> == "true" ]]; then
               yarn install
             else
               yarn install --frozen-lockfile


### PR DESCRIPTION
### Motivation, issues

I was unable to have the correct use of the `override-ci` option in the node/install-packages command.
After looking into the code, I detect a bug in the comparison used to detect if the "boolean" is true/false.

It's because, in bash, there is no boolean.
The current comparison is evaluate as a string.
So every time the script ran, the bash script think the `override-ci` value is `true` because there is some content.

