### PR TITLE
Expose install-package's cache-key parameter for configuration at job level

### DIFF
--- a/src/examples/run_node_tests_with_yarn.yml
+++ b/src/examples/run_node_tests_with_yarn.yml
@@ -1,0 +1,12 @@
+description: |
+  Drop-in solution to automatically test your NodeJS applications. This job will automatically download your code into any version node environment, install your dependencies using yarn with caching enabled, and execute your testing script.
+usage:
+  version: 2.1
+  orbs:
+    node: circleci/node@x.y # This version number refers to the version of the orb, not the version of NodeJS
+  workflows:
+    test-and-deploy:
+      jobs:
+        - node/test
+            pkg-manager: yarn
+            cache-key: "yarn.lock"

--- a/src/examples/run_node_tests_with_yarn.yml
+++ b/src/examples/run_node_tests_with_yarn.yml
@@ -7,6 +7,6 @@ usage:
   workflows:
     test-and-deploy:
       jobs:
-        - node/test
+        - node/test:
             pkg-manager: yarn
             cache-key: "yarn.lock"

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -13,6 +13,10 @@ parameters:
     enum: ["npm", "yarn"]
     default: "npm"
     description: Select the default node package manager to use.
+  cache-key:
+    type: string
+    default: "package-lock.json"
+    description: If this file is updated a new cache bucket will be created. Recommended to use package-lock.json.
   setup:
     type: steps
     description: Provide any optitonal steps you would like to run prior to installing the node dependencies. This is a good place to install global modules.
@@ -36,6 +40,7 @@ steps:
   - install-packages:
       app-dir: <<parameters.app-dir>>
       pkg-manager: <<parameters.pkg-manager>>
+      cache-key: <<parameters.cache-key>>
   - run:
       name: Run Node Tests
       working_directory: <<parameters.app-dir>>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

This allows `pkg-manager` to be set to `yarn` with a project that uses `yarn.lock` instead of `package-lock.json`.  Without this parameter the build fails when trying to calculate the cache key during `restore_cache` because `package-lock.json` doesn't exist.

Resolves #25 

### Description

Adds cache-key parameter to test job and example showing usage.
