### PR TITLE
Add minor version to executor tag

### DIFF
--- a/src/examples/run_tests_with_npm.yml
+++ b/src/examples/run_tests_with_npm.yml
@@ -9,7 +9,7 @@ usage:
     test:
       executor:
         name: node/default
-        tag: "13" # You could specify the node version via the docker image.
+        tag: "13.14" # You could specify the node version via the docker image.
       steps:
         - checkout
         - node/install-packages


### PR DESCRIPTION
It looks like the major version only tags aren't available for `cimg` on Dockerhub. This PR updates the two executor tags to include the latest minor release of Node 13 as listed [on this page in Docker hub](https://hub.docker.com/r/cimg/node/tags?page=1&name=13).