### PR TITLE
Lock yarn version for ci/cd tests [semver:minor]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ jobs:
       - node/install:
           node-version: "13.11.0"
           install-yarn: true # Test the install of YARN
+          yarn-version: "1.22.5"
       - run:
           command: |
             if ! node --version | grep -q "13"; then


### PR DESCRIPTION
Marking as semver:minor so that changes from https://github.com/CircleCI-Public/node-orb/pull/45 are properly deployed (deployment failed due to it - https://app.circleci.com/pipelines/github/CircleCI-Public/node-orb/624/workflows/efec1a76-947f-4298-8a92-63a40402eedf)