### PR TITLE
[semver:minor] Support for Yarn 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ integration-tests:
     integration-test-install-latest,
     integration-test-override-ci,
     integration-test-yarn,
+    integration-test-yarn-berry,
   ]
 
 executors:
@@ -111,6 +112,15 @@ jobs:
           cache-version: yarn-v3
           app-dir: "~/project/sample"
       - run: cd ~/project/sample && yarn test
+  integration-test-yarn-berry:
+    executor: node/default
+    steps:
+      - checkout
+      - node/install-packages:
+          pkg-manager: yarn-berry
+          cache-version: yarn-berry-v1
+          app-dir: "~/project/sample"
+      - run: cd ~/project/sample && yarn test
 
 workflows:
   # This `lint-pack_validate_publish-dev` workflow will run on any commit.
@@ -176,6 +186,7 @@ workflows:
           cache-version: v3
       - integration-test-override-ci
       - integration-test-yarn
+      - integration-test-yarn-berry
       - orb-tools/dev-promote-prod-from-commit-subject:
           orb-name: circleci/node
           context: orb-publishing

--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -4,7 +4,7 @@ description: >
 parameters:
   pkg-manager:
     type: enum
-    enum: ["npm", "yarn"]
+    enum: ["npm", "yarn", "yarn-berry"]
     default: "npm"
     description: Select the default node package manager to use.
   with-cache:
@@ -17,7 +17,7 @@ parameters:
     description: Path to the directory containing your package.json file. Not needed if package.json lives in the root.
   override-ci-command:
     description: |
-      By default, packages will be installed with "npm ci" or "yarn install --frozen-lockfile".
+      By default, packages will be installed with "npm ci", "yarn install --frozen-lockfile" or "yarn install --immutable".
       Optionally supply a custom package installation command, with any additional flags needed.
     type: string
     default: ""
@@ -139,3 +139,35 @@ steps:
                         key: node-deps-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "/tmp/node-project-lockfile" }}-{{ arch }}
                         paths:
                           - <<parameters.app-dir>>/node_modules
+                          
+- when: # Install packages based on YARN
+      condition:
+        equal: [yarn-berry, << parameters.pkg-manager >>]
+      steps:
+        - run:
+            name: Installing YARN packages
+            working_directory: <<parameters.app-dir>>
+            command: |
+              if [[ ! -z "<< parameters.override-ci-command >>" ]]; then
+                echo "Running override package installation command:"
+                << parameters.override-ci-command >>
+              else
+                yarn install --immutable
+              fi
+        - when: # cache enabled, save cache
+            condition: << parameters.with-cache >>
+            steps:
+              - when: # custom cache path selected
+                  condition: << parameters.cache-path >>
+                  steps:
+                    - save_cache:
+                        key: node-deps-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "/tmp/node-project-lockfile" }}-{{ arch }}
+                        paths:
+                          - <<parameters.cache-path>>
+              - unless: # use node modules
+                  condition: << parameters.cache-path >>
+                  steps:
+                    - save_cache:
+                        key: node-deps-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "/tmp/node-project-lockfile" }}-{{ arch }}
+                        paths:
+                          - <<parameters.app-dir>>/.yarn/cache

--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -139,8 +139,8 @@ steps:
                         key: node-deps-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "/tmp/node-project-lockfile" }}-{{ arch }}
                         paths:
                           - <<parameters.app-dir>>/node_modules
-                          
-- when: # Install packages based on YARN
+
+  - when: # Install packages based on YARN
       condition:
         equal: [yarn-berry, << parameters.pkg-manager >>]
       steps:

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -10,7 +10,7 @@ parameters:
       For a full list of releases, see the following: https://nodejs.org/en/download/releases
   pkg-manager:
     type: enum
-    enum: ["npm", "yarn"]
+    enum: ["npm", "yarn", "yarn-berry"]
     default: "npm"
     description: Select the default node package manager to use.
   cache-version:
@@ -62,5 +62,13 @@ steps:
       steps:
         - run:
             name: Run YARN Tests
+            working_directory: <<parameters.app-dir>>
+            command: yarn run <<parameters.run-command>>
+  - when: # Run tests for YARN 2.x
+      condition:
+        equal: [yarn-berry, << parameters.pkg-manager >>]
+      steps:
+        - run:
+            name: Run YARN 2.x Tests
             working_directory: <<parameters.app-dir>>
             command: yarn run <<parameters.run-command>>


### PR DESCRIPTION
This adds new `pkg-manager` enum value "yarn-berry" and related changes to CI commands and cache paths.

Closes #69