### PR TITLE
No period at the end of heading

### DIFF
--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -39,7 +39,7 @@ parameters:
 
 steps:
   - run:
-      name: Checking for package.json.
+      name: Checking for package.json
       working_directory: <<parameters.app-dir>>
       command: |
         if [ ! -f "package.json" ]; then


### PR DESCRIPTION
This makes "Checking for package.json" the same as the others.

<img width="367" alt="bild" src="https://user-images.githubusercontent.com/211/127148609-22162999-1932-4017-9b09-c88b4ccb9dbd.png">
