### PR TITLE
[semver:minor] Add node/run command for npm & yarn

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,6 +184,16 @@ workflows:
           name: node-test-job
           app-dir: "~/project/sample"
           cache-version: v3
+      - node/run:
+          name: node-run-job
+          app-dir: "~/project/sample"
+          cache-version: v4
+          npm-run: build
+      - node/run:
+          name: node-run-job
+          app-dir: "~/project/sample"
+          cache-version: v5
+          yarn-run: test
       - integration-test-override-ci
       - integration-test-yarn
       - integration-test-yarn-berry

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,7 +193,7 @@ workflows:
           name: node-run-job
           app-dir: "~/project/sample"
           cache-version: v5
-          yarn-run: test
+          yarn-run: build
       - integration-test-override-ci
       - integration-test-yarn
       - integration-test-yarn-berry

--- a/sample/package.json
+++ b/sample/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "nodemon --watch 'src/**/*.ts' --exec 'ts-node --require dotenv/config' src/index.ts",
-    "build": "tsc",
+    "build": "tsc -h",
     "start": "node dist/index.js",
     "test": "echo Simulated Node Tests"
   },

--- a/src/examples/node_npm_run.yml
+++ b/src/examples/node_npm_run.yml
@@ -1,0 +1,12 @@
+description: |
+  Drop-in solution to automatically run custom npm commands for your Node.js applications. 
+  This job will automatically download your code into any version node environment, install your dependencies with caching enabled, and execute your custom npm script.
+usage:
+  version: 2.1
+  orbs:
+    node: circleci/node@x.y # This version number refers to the version of the orb, not the version of Node.js
+  workflows:
+    run-npm-command:
+      jobs:
+        - node/run:
+            npm-run: build

--- a/src/examples/node_npm_run.yml
+++ b/src/examples/node_npm_run.yml
@@ -1,5 +1,5 @@
 description: |
-  Drop-in solution to automatically run custom npm commands for your Node.js applications. 
+  Drop-in solution to automatically run custom npm commands for your Node.js applications.
   This job will automatically download your code into any version node environment, install your dependencies with caching enabled, and execute your custom npm script.
 usage:
   version: 2.1

--- a/src/examples/node_yarn_run.yml
+++ b/src/examples/node_yarn_run.yml
@@ -1,0 +1,12 @@
+description: |
+  Drop-in solution to automatically run custom yarn commands for your Node.js applications. 
+  This job will automatically download your code into any version node environment, install your dependencies with caching enabled, and execute your custom yarn script.
+usage:
+  version: 2.1
+  orbs:
+    node: circleci/node@x.y # This version number refers to the version of the orb, not the version of Node.js
+  workflows:
+    run-npm-command:
+      jobs:
+        - node/run:
+            yarn-run: build

--- a/src/examples/node_yarn_run.yml
+++ b/src/examples/node_yarn_run.yml
@@ -1,5 +1,5 @@
 description: |
-  Drop-in solution to automatically run custom yarn commands for your Node.js applications. 
+  Drop-in solution to automatically run custom yarn commands for your Node.js applications.
   This job will automatically download your code into any version node environment, install your dependencies with caching enabled, and execute your custom yarn script.
 usage:
   version: 2.1

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -1,0 +1,63 @@
+description: |
+  Simple drop-in job to run commands for your Node.js application automatically.
+
+parameters:
+  version:
+    type: string
+    default: "13.11.0"
+    description: >
+      A full version tag must be specified. Example: "13.11.0"
+      For a full list of releases, see the following: https://nodejs.org/en/download/releases
+  pkg-manager:
+    type: enum
+    enum: ["npm", "yarn", "yarn-berry"]
+    default: "npm"
+    description: Select the default node package manager to use.
+  cache-version:
+    type: string
+    default: v1
+    description: Change the default cache version if you need to clear the cache for any reason.
+  setup:
+    type: steps
+    description: Provide any optional steps you would like to run prior to installing the node dependencies. This is a good place to install global modules.
+    default: []
+  npm-run:
+    type: string
+    default: ""
+    description: The name of the script within your package.json which you would like to run.
+  yarn-run:
+    type: string
+    default: ""
+    description: The name of the script within your package.json which you would like to run.
+  app-dir:
+    type: string
+    default: "~/project"
+    description: Path to the directory containing your package.json file. Not needed if package.json lives in the root.
+  override-ci-command:
+    description: |
+      By default, packages will be installed with "npm ci" or "yarn install --frozen-lockfile".
+      Optionally supply a custom package installation command, with any additional flags needed.
+    type: string
+    default: ""
+
+executor:
+  name: default
+  tag: << parameters.version >>
+
+steps:
+  - checkout
+  - steps: << parameters.setup >>
+  - install-packages:
+      app-dir: <<parameters.app-dir>>
+      pkg-manager: <<parameters.pkg-manager>>
+      cache-version: <<parameters.cache-version>>
+      override-ci-command: <<parameters.override-ci-command>>
+  - run:
+      name: Run <<parameters.pkg-manager>> <<parameters.npm-run>>
+      working_directory: <<parameters.app-dir>>
+      command: |
+        if [[ "npm" == "<<parameters.pkg-manager>>" ]]; then
+          npm run <<parameters.npm-run>>
+        else
+          yarn run <<parameters.yarn-run>>
+        fi


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [x] Minor
- [ ] Patch

## Description:

Adding a new job to run npm & yarn commands, similar to the node/test job.

## Motivation:

The only way to currently utilise the multiple steps already defined in the node/test job such as:
- checkout
- install
-  install-npm/yarn 
- install-packages

and then run your own custom command such as 'npm run build' is to pass in a run-command to the node/test job defined in your workflow. 

This change allows you to make use of the all the previous steps & run your own custom npm or yarn commands such as:

```
  workflows:
    run-npm-command:
      jobs:
        - node/run:
            npm-run: build
```

 **Closes Issues:**
N/A

## Checklist:

- [x] All new jobs, commands, executors, parameters have descriptions.
- [x] Usage Example version numbers have been updated.
- [x] Changelog has been updated.