### PR TITLE
[semver:minor] Prevent nvm from running "use" on initialization

### DIFF
--- a/src/scripts/install-nvm.sh
+++ b/src/scripts/install-nvm.sh
@@ -4,7 +4,7 @@ if command -v nvm &> /dev/null; then
 else
     curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash;
     echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV;
-    echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV;
+    echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" --no-use' >> $BASH_ENV;
     source $BASH_ENV;
 fi
 


### PR DESCRIPTION
If there's a `.nvmrc` file in the project with the required Nodejs version, the automatic invocation of "use" will read this file, which will lead to an error, because the respective version has not been downloaded yet. Adding the `--no-use`-flag should prevent this.