### PR TITLE
Use .nvmrc if lts and specific node version parameters are unspecified

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -9,10 +9,10 @@ parameters:
   # node
   node-version:
     type: string
-    default: "node"
+    default: ""
     description: >
       Specify the full version tag to install. To install the latest LTS version, set `lts` to true.
-      The latest (current) version of Node.js will be installed by default.
+      If unspecified, the version listed in .nvmrc will be installed. If no .nvmrc file exists the latest (current) version of Node.js will be installed by default.
       For a full list of releases, see the following: https://nodejs.org/en/download/releases
 
   lts:

--- a/src/scripts/install-nvm.sh
+++ b/src/scripts/install-nvm.sh
@@ -19,8 +19,7 @@ elif [ -f ".nvmrc" ]; then
     nvm install "$NVMRC_SPECIFIED_VERSION"
     nvm alias default "$NVMRC_SPECIFIED_VERSION"
 else
-    nvm install "node" 
-    nvm alias default "node"
+    nvm install "node"
 fi
 
 echo 'nvm use default &>/dev/null' >> $BASH_ENV

--- a/src/scripts/install-nvm.sh
+++ b/src/scripts/install-nvm.sh
@@ -11,9 +11,16 @@ fi
 if [ "$NODE_PARAM_LTS" = "1" ]; then
     nvm install --lts
     nvm alias default lts/*
-else
+elif [ -n "$NODE_PARAM_VERSION" ]; then
     nvm install "$NODE_PARAM_VERSION"
     nvm alias default "$NODE_PARAM_VERSION"
+elif [ -f ".nvmrc" ]; then
+    NVMRC_SPECIFIED_VERSION=$(<.nvmrc)
+    nvm install "$NVMRC_SPECIFIED_VERSION"
+    nvm alias default "$NVMRC_SPECIFIED_VERSION"
+else
+    nvm install "node" 
+    nvm alias default "node"
 fi
 
 echo 'nvm use default &>/dev/null' >> $BASH_ENV


### PR DESCRIPTION
After upgrading to the latest version of the node orb we noticed that the node install command was not respecting our project's `.nvmrc` file. I've updated the install script to check for the existence of an `.nvmrc` file when the lts parameter and node version parameters are unspecified. If no `.nvmrc` file exists the latest current version of node will be used instead.