### PR TITLE
remove symlinks at the end: lockfile, package.json

### DIFF
--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -174,4 +174,7 @@ steps:
                     - save_cache:
                         key: node-deps-{{ arch }}-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "/tmp/node-project-package.json" }}-{{ checksum "/tmp/node-project-lockfile" }}
                         paths:
-                          - <<parameters.app-dir>>/.yarn/cache
+                          - <<parameters.app-dir>>/.yarn/cache                
+  - run:
+      name: "Remove temporary links"
+      command: rm /tmp/node-project-lockfile /tmp/node-project-package.json

--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -174,7 +174,7 @@ steps:
                     - save_cache:
                         key: node-deps-{{ arch }}-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "/tmp/node-project-package.json" }}-{{ checksum "/tmp/node-project-lockfile" }}
                         paths:
-                          - <<parameters.app-dir>>/.yarn/cache                
+                          - <<parameters.app-dir>>/.yarn/cache
   - run:
       name: "Remove temporary links"
       command: rm /tmp/node-project-lockfile /tmp/node-project-package.json

--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -175,6 +175,9 @@ steps:
                         key: node-deps-{{ arch }}-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "/tmp/node-project-package.json" }}-{{ checksum "/tmp/node-project-lockfile" }}
                         paths:
                           - <<parameters.app-dir>>/.yarn/cache
-  - run:
-      name: "Remove temporary links"
-      command: rm /tmp/node-project-lockfile /tmp/node-project-package.json
+  - when:
+      condition: << parameters.with-cache >>
+      steps:
+        - run:
+            name: "Remove temporary links"
+            command: rm /tmp/node-project-lockfile /tmp/node-project-package.json


### PR DESCRIPTION
When `install-packages` is invoked twice in a job, the second usage fails:

```
ln: failed to create hard link '/tmp/node-project-lockfile': File exists
```

Removing `/tmp/node-project-lockfile` and `/tmp/node-project-package.json` solves this as these links are no longer needed after the command is done running.

Installing dependencies for two different projects can be useful for running integration tests. In that case you may need deps for the app and another set of dependencies for running the integration tests.