### PR TITLE
use correct cache key when cache-only-lockfile=true

### DIFF
--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -90,14 +90,14 @@ steps:
                   condition: << parameters.cache-path >>
                   steps:
                     - save_cache:
-                        key: node-deps-{{ arch }}-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "/tmp/node-project-package.json" }}-{{ checksum "/tmp/node-project-lockfile" }}
+                        key: node-deps-{{ arch }}-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>><<^parameters.cache-only-lockfile>>{{ checksum "/tmp/node-project-package.json" }}-<</parameters.cache-only-lockfile>>{{ checksum "/tmp/node-project-lockfile" }}
                         paths:
                           - << parameters.cache-path >>
               - unless: # npm ci cache path
                   condition: << parameters.cache-path >>
                   steps:
                     - save_cache:
-                        key: node-deps-{{ arch }}-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "/tmp/node-project-package.json" }}-{{ checksum "/tmp/node-project-lockfile" }}
+                        key: node-deps-{{ arch }}-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>><<^parameters.cache-only-lockfile>>{{ checksum "/tmp/node-project-package.json" }}-<</parameters.cache-only-lockfile>>{{ checksum "/tmp/node-project-lockfile" }}
                         paths:
                           - ~/.npm
 


### PR DESCRIPTION
Fixes #115

Do not include the `package.json` hash in the saved cache key when the "cache-only-lockfile" parameter is true.

This prioritizes exact-key matches when restoring.

Summary of behaviour with this change:
```
When parameters.cache-only-lockfile=true (default):
    Save:
        <common-prefix>{{ checksum "/tmp/node-project-lockfile" }}
    Restore:
        <common-prefix>{{ checksum "/tmp/node-project-lockfile" }}
        <common-prefix>{{ checksum "/tmp/node-project-package.json" }} <-- will never match, but should be OK
        <common-prefix>

When parameters.cache-only-lockfile=false:
    Save:
        <common-prefix>{{ checksum "/tmp/node-project-package.json" }}-{{ checksum "/tmp/node-project-lockfile" }}
    Restore:
        <common-prefix>{{ checksum "/tmp/node-project-package.json" }}-{{ checksum "/tmp/node-project-lockfile" }}
        <common-prefix>{{ checksum "/tmp/node-project-package.json" }}
        <common-prefix>
```