### PR TITLE
Fix Yarn Berry installs

### DIFF
--- a/src/scripts/packages/yarn-berry-install.sh
+++ b/src/scripts/packages/yarn-berry-install.sh
@@ -10,10 +10,10 @@ if [[ -n "$PARAM_OVERRIDE_COMMAND" ]]; then
 else
     # If a cache folder is already present, then we use Yarn Zero installs
     # See: https://yarnpkg.com/features/zero-installs
-    if [[ ! -f "$PARAM_CACHE_PATH" ]]; then
+    if [[ -f "$PARAM_CACHE_PATH" ]]; then
         # See: https://yarnpkg.com/features/zero-installs#does-it-have-security-implications
         YARN_LOCKFILE_PATH="/tmp/yarn-zero-lockfile"
-        
+
         if [[ "$PARAM_CHECK_CACHE" == "detect" ]]; then
             if [[ ! -f "$YARN_LOCKFILE_PATH" ]]; then
                 echo "No yarn zero lockfile cached. Enabling check cache this run."
@@ -26,13 +26,13 @@ else
                 echo "No changes detected in lockfile. Skipping check cache this run."
             fi
         fi
-        
+
         if [[ "$PARAM_CHECK_CACHE" == "always" || -n "$ENABLE_CHECK_CACHE" ]]; then
             set -- "$@" --check-cache
         fi
-        
+
         yarn install --immutable --immutable-cache "$@"
-        
+
         if [[ "$PARAM_CHECK_CACHE" == "detect" && -n "$ENABLE_CHECK_CACHE" ]]; then
             cp yarn.lock "$YARN_LOCKFILE_PATH"
         fi


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [ ] Minor
- [X] Patch

## Description:
Installing YARN Packages job failed when using yarn-berry without zero installs.
<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

## Motivation:
#130 - the `yarn install --immutable` line is not reachable.
<!---
  Share any open issues this PR references or otherwise describe the motivation to submit this pull request.
 -->

 **Closes Issues:**
-  #130

## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [X] All new jobs, commands, executors, parameters have descriptions.
- [ ] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.