### PR TITLE
Fix `lts` cannot be specified by node-version at node/install

### DIFF
--- a/src/scripts/install-nvm.sh
+++ b/src/scripts/install-nvm.sh
@@ -17,10 +17,10 @@ if [ "$NODE_PARAM_VERSION" = "latest" ]; then
     NODE_ORB_INSTALL_VERSION=$(nvm ls-remote | tail -n1 | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+')
     nvm install "$NODE_ORB_INSTALL_VERSION" # aka nvm install node. We're being explicit here.
     nvm alias default "$NODE_ORB_INSTALL_VERSION"
-    elif [ -n "$NODE_PARAM_VERSION" ]; then
+elif [ -n "$NODE_PARAM_VERSION" ] && [ "$NODE_PARAM_VERSION" != "lts" ]; then
     nvm install "$NODE_PARAM_VERSION"
     nvm alias default "$NODE_PARAM_VERSION"
-    elif [ -f ".nvmrc" ]; then
+elif [ -f ".nvmrc" ]; then
     NVMRC_SPECIFIED_VERSION=$(<.nvmrc)
     nvm install "$NVMRC_SPECIFIED_VERSION"
     nvm alias default "$NVMRC_SPECIFIED_VERSION"


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [ ] Minor
- [x] Patch

## Description:

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Document says 

```
 To install the latest LTS version, set the version to `lts`.
```
https://circleci.com/developer/ja/orbs/orb/circleci/node?version=5.0.0#commands-install

But, `node-version: lts` fails with following error.

```
Version 'lts' not found - try `nvm ls-remote` to browse available versions.

Exited with code exit status 3
```

This is causes by script does not handle `node-version: lts` well.
This PR fixes the issue.

## Motivation:

<!---
  Share any open issues this PR references or otherwise describe the motivation to submit this pull request.
 -->

I want to set and fix node version `lts`, but with version 5.0.0, I can't.


## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions.
- [x] Usage Example version numbers have been updated.
- [x] Changelog has been updated.