### PR TITLE
fix: yarn install fails when release is tagged in GitHub but not yet published on yarnpkg.com

### DIFF
--- a/src/scripts/install-yarn.sh
+++ b/src/scripts/install-yarn.sh
@@ -3,8 +3,7 @@ if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 # FUNCTIONS
 get_yarn_version () {
     if [[ "$NODE_PARAM_YARN_VERSION" == "" ]]; then
-    YARN_ORB_VERSION=$(curl -Ls -o /dev/null -w "%{url_effective}" \
-        "https://github.com/yarnpkg/yarn/releases/latest" | sed 's:.*/::' | cut -d 'v' -f 2 | cut -d 'v' -f 2)
+    YARN_ORB_VERSION=$(curl -s https://cdn.jsdelivr.net/npm/yarn/package.json | sed -n 's/.*version": "\(.*\)".*/\1/p')
     echo "Latest version of Yarn is $YARN_ORB_VERSION"
     else
     YARN_ORB_VERSION="$NODE_PARAM_YARN_VERSION"


### PR DESCRIPTION
We should check the latest version at the same source we will download from.
In this solution, we use the package.json published on https://yarnpkg.com/package/yarn to resolve the latest version.

At the time of the problem, version 1.22.18 was tagged as a release on GitHub but 1.22.17 was the latest version on yarnpkg.com. 
The error was:

```
Latest version of Yarn is 1.22.18
Checking if YARN is already installed...
A different version of Yarn is installed (1.22.17); removing it
Installing YARN v1.22.18

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
mv: cannot stat ‘yarn-v1.22.18/*’: No such file or directory

Exited with code exit status 1

CircleCI received exit code 1
```