### PR TITLE
Swap order of steps in npm install example

### DIFF
--- a/src/examples/npm_install.yml
+++ b/src/examples/npm_install.yml
@@ -9,10 +9,10 @@ usage:
             executor: node/default
             steps:
                 - checkout
+                - run: sudo npm install -g npm@latest
                 - node/install-packages:
                       override-ci-command: npm install
                       cache-path: ~/project/node_modules
-                - run: sudo npm install -g npm@latest
                 - run: npm run test
     workflows:
         test_my_app:


### PR DESCRIPTION
If `node/install-packages` comes first, the packages will already be installed
before the correct version of npm has been installed.

It'll look something a bit like this:
```
        environment:
          PARAM_CACHE_PATH: ''
          PARAM_OVERRIDE_COMMAND: npm install
        name: Installing NPM packages
        working_directory: .
    - save_cache:
        key: node-deps-{{ arch }}-v1-{{ .Branch }}-{{ checksum "/tmp/node-project-lockfile" }}
        paths:
        - ~/.npm
    - run:
        command: rm -f /tmp/node-project-lockfile /tmp/node-project-package.json /tmp/yarn-zero-lockfile
        name: Remove temporary links
    - run:
        command: sudo npm install -g npm@latest
```

whereas presumably we want something like this instead:
```
    - checkout
    - run:
        command: "# Only install nvm if it's not already installed\..."
        environment:
          NODE_PARAM_VERSION: '16.14'
        name: Install Node.js 16.14
    - run:
        command: sudo npm install -g npm@latest
    - run:
        command: |-
          # Fail if package.json does not exist in working directory

          if [ ! -f "package.json" ]; then
```