### PR TITLE
Ask curl to retry 5 times on yarn download

### DIFF
--- a/src/scripts/install-yarn.sh
+++ b/src/scripts/install-yarn.sh
@@ -49,7 +49,7 @@ installation_check
 
 # install yarn
 echo "Installing YARN v$YARN_ORB_VERSION"
-curl -L -o yarn.tar.gz --silent "https://yarnpkg.com/downloads/$YARN_ORB_VERSION/yarn-v$YARN_ORB_VERSION.tar.gz"
+curl --retry 5 -L -o yarn.tar.gz --silent "https://yarnpkg.com/downloads/$YARN_ORB_VERSION/yarn-v$YARN_ORB_VERSION.tar.gz"
 
 $SUDO tar -xzf yarn.tar.gz && rm yarn.tar.gz
 


### PR DESCRIPTION
The errors may be transient, and the --retry option is about re-attempting to download on a transient error.

Learn more about the retry option:
https://daniel.haxx.se/blog/2020/03/24/curl-ootw-retry-max-time/

## Limitations

This doesn't account for "something not gzip got downloaded, like an CDN HTML error page":

```
Selected version of Yarn is 1.22.19
Checking if YARN is already installed...
Installing YARN v1.22.19

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
mv: cannot stat 'yarn-v1.22.19/*': No such file or directory
```