### PR TITLE
fix: support cache computation on windows

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -29,7 +29,11 @@ executors:
   machine:
     machine:
       image: ubuntu-2004:202111-01
-
+  windows:
+    machine:
+      image: windows-server-2022-gui:current
+      shell: bash.exe
+    resource_class: windows.medium
 jobs:
   # Install Node.js into a non-node container.
   integration-test-install-specified-version:
@@ -104,6 +108,21 @@ jobs:
     executor: node/default
     steps:
       - checkout
+      - node/install-packages:
+          override-ci-command: npm install
+          cache-path: ~/project/node_modules
+          cache-version: override-v3
+          app-dir: "~/project/sample"
+      - run: cd ~/project/sample && npm run test
+  integration-test-override-ci-windows:
+    executor: windows
+    steps:
+      - checkout
+      - run:
+          name: Install Node.js
+          command: |
+            nvm install lts
+            nvm use lts
       - node/install-packages:
           override-ci-command: npm install
           cache-path: ~/project/node_modules
@@ -284,6 +303,10 @@ workflows:
           pkg-manager: yarn
           yarn-run: build
       - integration-test-override-ci:
+          filters:
+            tags:
+              only: /.*/  
+      - integration-test-override-ci-windows:
           filters:
             tags:
               only: /.*/  

--- a/src/scripts/packages/determine-lockfile.sh
+++ b/src/scripts/packages/determine-lockfile.sh
@@ -1,5 +1,5 @@
 TARGET_DIR="/tmp"
-if ! [ -z $HOMEDRIVE ]; then
+if [ -n $HOMEDRIVE ]; then
     TARGET_DIR="$HOMEDRIVE\\tmp\\"
 fi
 

--- a/src/scripts/packages/determine-lockfile.sh
+++ b/src/scripts/packages/determine-lockfile.sh
@@ -1,6 +1,6 @@
 TARGET_DIR="/tmp"
 if [ -n "$HOMEDRIVE" ]; then
-    TARGET_DIR="$HOMEDRIVE\\tmp\\"
+    TARGET_DIR="$HOMEDRIVE\\tmp"
 fi
 
 # Link corresponding lock file to a temporary file used by cache commands

--- a/src/scripts/packages/determine-lockfile.sh
+++ b/src/scripts/packages/determine-lockfile.sh
@@ -1,5 +1,5 @@
 TARGET_DIR="/tmp"
-if [ -n $HOMEDRIVE ]; then
+if [ -n "$HOMEDRIVE" ]; then
     TARGET_DIR="$HOMEDRIVE\\tmp\\"
 fi
 

--- a/src/scripts/packages/determine-lockfile.sh
+++ b/src/scripts/packages/determine-lockfile.sh
@@ -1,12 +1,18 @@
+TARGET_DIR="/tmp"
+if ! [ -z $HOMEDRIVE ]; then
+    TARGET_DIR="$HOMEDRIVE\\tmp\\"
+fi
+
 # Link corresponding lock file to a temporary file used by cache commands
 if [ -f "package-lock.json" ]; then
     echo "Found package-lock.json file, assuming lockfile"
-    cp package-lock.json /tmp/node-project-lockfile
+    cp package-lock.json $TARGET_DIR/node-project-lockfile
 elif [ -f "npm-shrinkwrap.json" ]; then
     echo "Found npm-shrinkwrap.json file, assuming lockfile"
-    cp npm-shrinkwrap.json /tmp/node-project-lockfile
+    cp npm-shrinkwrap.json $TARGET_DIR/node-project-lockfile
 elif [ -f "yarn.lock" ]; then
     echo "Found yarn.lock file, assuming lockfile"
-    cp yarn.lock /tmp/node-project-lockfile
+    cp yarn.lock $TARGET_DIR/node-project-lockfile
 fi
-cp package.json /tmp/node-project-package.json
+
+cp package.json $TARGET_DIR/node-project-package.json


### PR DESCRIPTION
On windows runners, the cache keys fails to be computed because of the `checksum` function that can't find the file in /tmp. Indeed, it seems that bash `/tmp` is not the runner's `C:\tmp` directory.

See https://app.circleci.com/pipelines/github/KnodesCommunity/typedoc-plugins/693/workflows/897cb674-230e-46ae-99f5-b10d93f4b723/jobs/3872/parallel-runs/0/steps/0-106 for an example of failed step