### PR TITLE
fix: remove unused node-install-dir parameter

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -15,12 +15,6 @@ parameters:
             If unspecified, the version listed in .nvmrc will be installed. If no .nvmrc file exists the active LTS version of Node.js will be installed by default.
             For a full list of releases, see the following: https://nodejs.org/en/download/releases
 
-    node-install-dir:
-        type: string
-        default: /usr/local
-        description: >
-            Where should Node.js be installed?
-
     # yarn
     install-yarn:
         type: boolean

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -15,12 +15,6 @@ parameters:
             If unspecified, the version listed in .nvmrc or .node-version will be installed. If no .nvmrc file and .node-version file exists the active LTS version of Node.js will be installed by default.
             For a full list of releases, see the following: https://nodejs.org/en/download/releases
 
-    node-install-dir:
-        type: string
-        default: /usr/local
-        description: >
-            Where should Node.js be installed?
-
     # pnpm
     install-pnpm:
         type: boolean


### PR DESCRIPTION
`node-install-dir` isn't hooked up to anything, and appears to have never been. It's not documented (beyond automatically as a parameter) or tested. Technically a "breaking change" since it removes a parameter, but since the parameter has always been a no-op, there's no functional break (but anyone using the parameter in a config thinking it did something would get an error on updating).