### PR TITLE
fix: Fixing cache load step breaking when no lock file is detected

### DIFF
--- a/src/scripts/packages/determine-lockfile.sh
+++ b/src/scripts/packages/determine-lockfile.sh
@@ -13,6 +13,9 @@ elif [ -f "npm-shrinkwrap.json" ]; then
 elif [ -f "yarn.lock" ]; then
     echo "Found yarn.lock file, assuming lockfile"
     cp yarn.lock $TARGET_DIR/node-project-lockfile
+else
+    echo "Found no lockfile, adding empty one"
+    touch $TARGET_DIR/node-project-lockfile
 fi
 
 cp package.json $TARGET_DIR/node-project-package.json


### PR DESCRIPTION
If your project does not contain any lockfile at all, this logic falls through and does not copy anything to `$TARGET_DIR/node-project-lockfile`: https://github.com/CircleCI-Public/node-orb/blob/ab05d0e3718e32232bdd9c80a8ba6fac1c0bee02/src/scripts/packages/determine-lockfile.sh#L6-L16

However, if you run this without `with-cache: false`, this step fails: https://github.com/CircleCI-Public/node-orb/blob/ab05d0e3718e32232bdd9c80a8ba6fac1c0bee02/src/commands/install-packages.yml#L70

As:

```
error computing cache key: template: cacheKey:1:41: executing "cacheKey" at <checksum "/tmp/node-project-lockfile">: error calling checksum: open /tmp/node-project-lockfile: no such file or directory
```

## Expected behavior:

Caching step should complete without a lockfile present.