### PR TITLE
feat: support Yarn Berry global cache

### DIFF
--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -176,7 +176,8 @@ steps:
                                   - save_cache:
                                         key: node-deps-{{ arch }}-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>><<^parameters.cache-only-lockfile>>{{ checksum "/tmp/node-project-package.json" }}-<</parameters.cache-only-lockfile>>{{ checksum "/tmp/node-project-lockfile" }}
                                         paths:
-                                            - <<parameters.app-dir>>/.yarn/cache
+                                            - ~/.yarn/berry/cache # global cache, the default in Yarn Berry v4+
+                                            - <<parameters.app-dir>>/.yarn/cache # project cache, the default in Yarn Berry > 2 and < 4
     - when:
           condition: << parameters.with-cache >>
           steps:


### PR DESCRIPTION
In Yarn Berry v4+, the default is to cache dependencies into a global cache (`~/.yarn/berry/cache`), as you can see here:

```shell
 docker run -it --entrypoint bash node:20
root@2d1b6b79999d:/# corepack enable
root@2d1b6b79999d:/# mkdir test-berry && cd test-berry
root@2d1b6b79999d:/test-berry# yarn init -y
yarn init v1.22.21
warning The yes flag has been set. This will automatically answer yes to all questions, which may have security implications.
success Saved package.json
Done in 0.01s.
root@2d1b6b79999d:/test-berry# yarn set version berry
➤ YN0000: Done in 0s 13ms
root@2d1b6b79999d:/test-berry# yarn --version
4.0.2
root@2d1b6b79999d:/test-berry# yarn add semver
➤ YN0000: · Yarn 4.0.2
➤ YN0000: ┌ Resolution step
➤ YN0085: │ + semver@npm:7.5.4, lru-cache@npm:6.0.0, yallist@npm:4.0.0
➤ YN0000: └ Completed in 0s 593ms
➤ YN0000: ┌ Fetch step
➤ YN0013: │ 3 packages were added to the project (+ 130.97 KiB).
➤ YN0000: └ Completed
➤ YN0000: ┌ Link step
➤ YN0000: └ Completed
➤ YN0000: · Done in 0s 769ms
root@2d1b6b79999d:/test-berry# ls -al ~/.yarn/berry/cache
total 144
drwxr-xr-x 2 root root   4096 Dec  7 15:57 .
drwxr-xr-x 5 root root   4096 Dec  7 15:57 ..
-rw-r--r-- 1 root root  16449 Dec  7 15:57 lru-cache-npm-6.0.0-b4c8668fe1-10c0.zip
-rw-r--r-- 1 root root 101983 Dec  7 15:57 semver-npm-7.5.4-c4ad957fcd-10c0.zip
-rw-r--r-- 1 root root  15682 Dec  7 15:57 yallist-npm-4.0.0-b493d9e907-10c0.zip
root@2d1b6b79999d:/test-berry# ls .yarn/cache
ls: cannot access '.yarn/cache': No such file or directory
root@2d1b6b79999d:/test-berry#
```

To make this work transparently for all Yarn Berry users, we should cache both the global and project-level caches.