### PR TITLE
feat: optionally store artifacts after script in run job

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -222,6 +222,13 @@ workflows:
           cache-version: v5
           pkg-manager: yarn
           yarn-run: build
+      - node/run:
+          filters: *filters
+          name: node-run-upload-artifacts
+          app-dir: "~/project/sample"
+          cache-version: v4
+          npm-run: build
+          artifacts-path: "~/project/sample/dist"
       - integration-test-override-ci:
           filters: *filters 
       - integration-test-override-ci-windows:

--- a/sample/dist/index.js
+++ b/sample/dist/index.js
@@ -1,0 +1,1 @@
+console.log("Hello World!");

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -38,6 +38,11 @@ parameters:
             Optionally supply a custom package installation command, with any additional flags needed.
         type: string
         default: ''
+    artifacts-path:
+        description: |
+            Path to a file or directory to upload to artifacts after running the script.
+        type: string
+        default: ''
     resource_class:
         default: large
         description: Configure the executor resource class
@@ -72,3 +77,8 @@ steps:
               ORB_PARAM_NPM_RUN: <<parameters.npm-run>>
               ORB_PARAM_YARN_RUN: <<parameters.yarn-run>>
           command: <<include(scripts/run-commands-with.sh)>>
+    - when:
+          condition: <<parameters.artifacts-path>>
+          steps:
+              - store_artifacts:
+                    path: <<parameters.artifacts-path>>


### PR DESCRIPTION

**SEMVER Update Type:**
- [ ] Major
- [x] Minor
- [ ] Patch

## Description:

* add a parameter to upload a path to artifacts after running a script in the `run` job

## Motivation:

Running a script often produces new files to be stored as artifacts. For example, many front-end projects use a bundler such as Webpack or Vite, and TypeScript projects need to be transpiled to JavaScript. These tools are often controlled with  a `build`, `compile` or `webpack` script.

After this step, the produced files often need to be persisted somewhere, and artifacts seems like a good place.

## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions.
- [ ] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.