### PR TITLE
feat: upload coverage to artifacts in test job

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -330,7 +330,7 @@ workflows:
           app-dir: "~/project/sample"
           cache-version: v4
           run-command: "test:coverage"
-          test-coverage-path: coverage
+          test-coverage-path: ~/project/sample/coverage
       - node/run:
           filters: *filters
           name: node-run-npm-job

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -209,6 +209,13 @@ workflows:
           name: node-test-no-junit
           app-dir: "~/project/sample"
           cache-version: v4
+      - node/test:
+          filters: *filters
+          name: node-test-with-coverage
+          app-dir: "~/project/sample"
+          cache-version: v4
+          run-command: "test:coverage"
+          test-coverage-path: coverage
       - node/run:
           filters: *filters
           name: node-run-npm-job

--- a/sample/package.json
+++ b/sample/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -h",
     "start": "node dist/index.js",
     "test": "jest jest-tests",
-    "testmocha": "mocha mocha-tests"
+    "testmocha": "mocha mocha-tests",
+    "test:coverage": "jest --coverage jest-tests"
   },
   "author": "",
   "license": "ISC",

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -48,6 +48,12 @@ parameters:
             Testing framework your project uses.
             If this is set to jest or mocha, test results will be automatically produced. When using jest, the jest-junit package is required as a dev dependency. See https://github.com/jest-community/jest-junit for more information.
             When using mocha, the mocha-junit-reporter and mocha-multi packages are required as dev dependency. See https://github.com/michaelleeallen/mocha-junit-reporter and https://github.com/glenjamin/mocha-multi for more information.
+    test-coverage-path:
+        type: string
+        default: ''
+        description: |
+            Set this to the location where code coverage files will be placed after running tests.
+            The code coverage files will be uploaded to artifacts for this workflow.
     resource_class:
         default: large
         description: Configure the executor resource class
@@ -205,3 +211,8 @@ steps:
           steps:
               store_test_results:
                   path: <<parameters.app-dir>>/test-results.xml
+    - when: # upload coverage files if test-coverage-path was configured
+          condition: <<parameters.test-coverage-path>>
+          steps:
+              - store_artifacts:
+                    path: <<parameters.test-coverage-path>>


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [x] Minor
- [ ] Patch

## Description:

* add a parameter to upload test coverage to artifacts after running the `test` job

## Motivation:

As recommended in the [CircleCI documentation](https://circleci.com/docs/code-coverage), uploading test coverage to artifacts is a good practice. This PR allows for uploading coverage files to artifacts by supplying the coverage path as an argument to the `test` job.

## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions.
- [ ] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.