### PR TITLE
feat: support .node-version file

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -78,6 +78,16 @@ jobs:
       - run: echo '16.13' > .nvmrc
       - node/install
 
+  integration-test-use-node-version-version:
+    parameters:
+      os:
+        type: executor
+    executor: <<parameters.os>>
+    steps:
+      - checkout
+      - run: echo '16.13' > .node-version
+      - node/install
+
   integration-test-install-lts:
     parameters:
       os:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -12,7 +12,7 @@ parameters:
         default: ''
         description: >
             Specify the full version tag to install. To install the latest version, set the version to `latest`.
-            If unspecified, the version listed in .nvmrc will be installed. If no .nvmrc file exists the active LTS version of Node.js will be installed by default.
+            If unspecified, the version listed in .nvmrc or .node-version will be installed. If no .nvmrc file and .node-version file exists the active LTS version of Node.js will be installed by default.
             For a full list of releases, see the following: https://nodejs.org/en/download/releases
 
     node-install-dir:

--- a/src/scripts/install-nvm.sh
+++ b/src/scripts/install-nvm.sh
@@ -27,6 +27,10 @@ elif [ -f ".nvmrc" ]; then
     NVMRC_SPECIFIED_VERSION=$(<.nvmrc)
     nvm install "$NVMRC_SPECIFIED_VERSION"
     nvm alias default "$NVMRC_SPECIFIED_VERSION"
+elif [ -f ".node-version" ]; then
+    NVMRC_SPECIFIED_VERSION=$(<.node-version)
+    nvm install "$NVMRC_SPECIFIED_VERSION"
+    nvm alias default "$NVMRC_SPECIFIED_VERSION"
 else
     nvm install --lts
     nvm alias default lts/*


### PR DESCRIPTION
**SEMVER Update Type:**
- [x] Major
- [ ] Minor
- [ ] Patch

## Description:

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

support .node-version file

## Motivation:

<!---
  Share any open issues this PR references or otherwise describe the motivation to submit this pull request.
 -->

Most Node.js runtime managers support either `.nvmrc` or `.node-version` (nodenv etc...) or both (fnm, mise, asdf etc...) are supported.

However, currently only `.nvmrc` is supported.

Although it is preferable to use `.nvmrc` since we use `nvm` internally, both `.nvmrc` and `.node-version` are often in the same format.

It is possible that I am missing a specification, but I don't think it will be a problem in many cases.

## Test

https://app.circleci.com/pipelines/github/totto2727/node-orb

## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions.
- [ ] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.
