### PR TITLE
Fix: yarn berry install packages

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -172,6 +172,7 @@ jobs:
           pkg-manager: yarn
           cache-version: yarn-v3
           app-dir: "~/project/sample"
+      - run: yarn --version
       - run: cd ~/project/sample && yarn test
   integration-test-yarn-berry:
     executor:
@@ -182,6 +183,7 @@ jobs:
           pkg-manager: yarn-berry
           cache-version: yarn-berry-v1
           app-dir: "~/project/sample"
+      - run: yarn --version
       - run: cd ~/project/sample && yarn test
 
 workflows:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -180,6 +180,7 @@ jobs:
     steps:
       - checkout
       - run: mv ~/project/sample/package-berry.json ~/project/sample/package.json
+      - run: rm ~/project/sample/yarn.lock
       - node/install-packages:
           pkg-manager: yarn-berry
           cache-version: yarn-berry-v2

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -183,6 +183,7 @@ jobs:
       - checkout
       - run: mv ~/project/sample/package-berry.json ~/project/sample/package.json
       - run: echo y | yarn set version berry
+      - run: yarn install
       # - run: rm ~/project/sample/yarn.lock
       - node/install-packages:
           pkg-manager: yarn-berry

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -182,6 +182,7 @@ jobs:
     steps:
       - checkout
       - run: mv ~/project/sample/package-berry.json ~/project/sample/package.json
+      - run: echo y | yarn set version berry
       # - run: rm ~/project/sample/yarn.lock
       - node/install-packages:
           pkg-manager: yarn-berry

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -182,15 +182,11 @@ jobs:
     steps:
       - checkout
       - run: mv ~/project/sample/package-berry.json ~/project/sample/package.json
-      - run: corepack enable --install-directory ~/bin
-      - run: echo y | yarn set version berry
-      - run: yarn install
-      - run: echo "export YARN_ENABLE_IMMUTABLE_INSTALLS=false" >> "$BASH_ENV" && source "$BASH_ENV"
-      # - run: rm ~/project/sample/yarn.lock
       - node/install-packages:
           pkg-manager: yarn-berry
           cache-version: yarn-berry-v2
           app-dir: "~/project/sample"
+          override-ci-command: yarn install
       - run: yarn --version
       - run: cd ~/project/sample && yarn test
 

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -179,6 +179,7 @@ jobs:
       name: node/default
     steps:
       - checkout
+      - run: mv package-berry.json package.json
       - node/install-packages:
           pkg-manager: yarn-berry
           cache-version: yarn-berry-v1

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -182,6 +182,7 @@ jobs:
     steps:
       - checkout
       - run: mv ~/project/sample/package-berry.json ~/project/sample/package.json
+      - run: corepack enable --install-directory ~/bin
       - run: echo y | yarn set version berry
       - run: yarn install
       # - run: rm ~/project/sample/yarn.lock

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -175,12 +175,14 @@ jobs:
       - run: yarn --version
       - run: cd ~/project/sample && yarn test
   integration-test-yarn-berry:
+    environment:
+      YARN_ENABLE_IMMUTABLE_INSTALLS: false
     executor:
       name: node/default
     steps:
       - checkout
       - run: mv ~/project/sample/package-berry.json ~/project/sample/package.json
-      - run: rm ~/project/sample/yarn.lock
+      # - run: rm ~/project/sample/yarn.lock
       - node/install-packages:
           pkg-manager: yarn-berry
           cache-version: yarn-berry-v2

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -185,6 +185,7 @@ jobs:
       - run: corepack enable --install-directory ~/bin
       - run: echo y | yarn set version berry
       - run: yarn install
+      - run: echo "export YARN_ENABLE_IMMUTABLE_INSTALLS=false" >> "$BASH_ENV" && source "$BASH_ENV"
       # - run: rm ~/project/sample/yarn.lock
       - node/install-packages:
           pkg-manager: yarn-berry

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -179,7 +179,7 @@ jobs:
       name: node/default
     steps:
       - checkout
-      - run: mv package-berry.json package.json
+      - run: mv ~/project/sample/package-berry.json ~/project/sample/package.json
       - node/install-packages:
           pkg-manager: yarn-berry
           cache-version: yarn-berry-v1

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -187,7 +187,6 @@ jobs:
           cache-version: yarn-berry-v2
           app-dir: "~/project/sample"
           override-ci-command: yarn install
-      - run: yarn --version
       - run: cd ~/project/sample && yarn test
 
 workflows:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -182,7 +182,7 @@ jobs:
       - run: mv ~/project/sample/package-berry.json ~/project/sample/package.json
       - node/install-packages:
           pkg-manager: yarn-berry
-          cache-version: yarn-berry-v1
+          cache-version: yarn-berry-v2
           app-dir: "~/project/sample"
       - run: yarn --version
       - run: cd ~/project/sample && yarn test

--- a/sample/package-berry.json
+++ b/sample/package-berry.json
@@ -1,6 +1,6 @@
 {
   "name": "opd-server",
-  "packageManager": "yarn@4.3.0",
+  "packageManager": "yarn@4.4.1",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/sample/package-berry.json
+++ b/sample/package-berry.json
@@ -1,5 +1,6 @@
 {
   "name": "opd-server",
+  "packageManager": "yarn@4.3.0",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/sample/package-berry.json
+++ b/sample/package-berry.json
@@ -1,6 +1,6 @@
 {
   "name": "opd-server",
-  "packageManager": "yarn@4.4.1",
+  "packageManager": "yarn@4.3.0",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/sample/package.json
+++ b/sample/package.json
@@ -1,5 +1,6 @@
 {
   "name": "opd-server",
+  "packageManager": "yarn@4.3.0",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -7,8 +7,8 @@ parameters:
         type: enum
         enum: ['npm', 'yarn', 'yarn-berry', 'pnpm']
         default: 'npm'
-        description: | 
-            Select the default node package manager to use. NPM v5+ Required. 
+        description: |
+            Select the default node package manager to use. NPM v5+ Required.
             To use yarn-berry your package.json must have packageManager set to a yarn berry version, otherwise it will use old yarn.
     with-cache:
         type: boolean

--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -7,7 +7,9 @@ parameters:
         type: enum
         enum: ['npm', 'yarn', 'yarn-berry', 'pnpm']
         default: 'npm'
-        description: Select the default node package manager to use. NPM v5+ Required.
+        description: | 
+            Select the default node package manager to use. NPM v5+ Required. 
+            To use yarn-berry your package.json must have packageManager set to a yarn berry version, otherwise it will use old yarn.
     with-cache:
         type: boolean
         default: true

--- a/src/scripts/packages/yarn-berry-install.sh
+++ b/src/scripts/packages/yarn-berry-install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+corepack enable
 # Run override ci command if provided, otherwise run default yarn install
 # See: https://yarnpkg.com/configuration/yarnrc/#cacheFolder
 if [[ -n "$PARAM_CACHE_PATH" ]]; then
@@ -33,12 +33,12 @@ else
             set -- "$@" --check-cache
         fi
 
-        yarn install --immutable --immutable-cache "$@"
+        echo y | yarn install --immutable --immutable-cache "$@"
 
         if [[ "$PARAM_CHECK_CACHE" == "detect" && -n "$ENABLE_CHECK_CACHE" ]]; then
             cp yarn.lock "$YARN_LOCKFILE_PATH"
         fi
     else
-        yarn install --immutable
+        echo y | yarn install --immutable
     fi
 fi

--- a/src/scripts/packages/yarn-berry-install.sh
+++ b/src/scripts/packages/yarn-berry-install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-$SUDO corepack enable
+corepack enable --install-directory ~/bin
 # Run override ci command if provided, otherwise run default yarn install
 # See: https://yarnpkg.com/configuration/yarnrc/#cacheFolder
 if [[ -n "$PARAM_CACHE_PATH" ]]; then

--- a/src/scripts/packages/yarn-berry-install.sh
+++ b/src/scripts/packages/yarn-berry-install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-corepack enable
+$SUDO corepack enable
 # Run override ci command if provided, otherwise run default yarn install
 # See: https://yarnpkg.com/configuration/yarnrc/#cacheFolder
 if [[ -n "$PARAM_CACHE_PATH" ]]; then


### PR DESCRIPTION
In the install-packages command, when setting pkg-manager to yarn-berry, it was no using yarn-berry but the old version of yarn. I'm enabling corepack in the script that installs with yarn berry, so it uses yarn-berry.
Yarn berry takes the version from package.json so this will only work when that's specified, otherwise it will use old yarn.
This is done this way to avoid setting wrong default version.

This should solve #217 