### PR TITLE
Fix: reinstall a new version of yarn on machine executor

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -62,7 +62,11 @@ jobs:
               echo "pnpm version 9.7.1 not found"
               exit 1
             fi
-
+  integration-test-reinstall-yarn:
+    machine:
+      image: ubuntu-2004:current
+    steps:
+      - node/install-yarn
   integration-test-install-latest:
     parameters:
       os:
@@ -187,6 +191,7 @@ jobs:
 workflows:
   test-deploy:
     jobs:
+      - integration-test-reinstall-yarn
       - integration-test-install-specified-version:
           filters: *filters
           matrix:
@@ -399,6 +404,7 @@ workflows:
             - integration-test-install-lts
             - integration-test-install-pnpm
             - integration-test-pnpm
+            - integration-test-reinstall-yarn
             - node-yarn-mocha-with-test-result-path-job
             - node-test-results-file-job
             - node-run-npm-job

--- a/src/scripts/install-yarn.sh
+++ b/src/scripts/install-yarn.sh
@@ -29,9 +29,13 @@ installation_check () {
             elif grep Debian /etc/issue > /dev/null 2>&1; then
                 $SUDO apt-get remove yarn > /dev/null 2>&1 && \
                 $SUDO apt-get purge yarn > /dev/null 2>&1
+                OLD_YARN=$(which yarn)
+                rm $OLD_YARN
             elif grep Ubuntu /etc/issue > /dev/null 2>&1; then
                 $SUDO apt-get remove yarn > /dev/null 2>&1 && \
                 $SUDO apt-get purge yarn > /dev/null 2>&1
+                OLD_YARN=$(which yarn)
+                rm $OLD_YARN
             elif command -v yum > /dev/null 2>&1; then
                 yum remove yarn > /dev/null 2>&1
             fi

--- a/src/scripts/install-yarn.sh
+++ b/src/scripts/install-yarn.sh
@@ -5,41 +5,40 @@ if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 # FUNCTIONS
 get_yarn_version () {
     if [[ "$NODE_PARAM_YARN_VERSION" == "" ]]; then
-    YARN_ORB_VERSION=$(curl -s https://cdn.jsdelivr.net/npm/yarn/package.json | sed -n 's/.*version": "\(.*\)".*/\1/p')
-    echo "Latest version of Yarn is $YARN_ORB_VERSION"
+        YARN_ORB_VERSION=$(curl -s https://cdn.jsdelivr.net/npm/yarn/package.json | sed -n 's/.*version": "\(.*\)".*/\1/p')
+        echo "Latest version of Yarn is $YARN_ORB_VERSION"
     else
-    YARN_ORB_VERSION="$NODE_PARAM_YARN_VERSION"
-
-    echo "Selected version of Yarn is $YARN_ORB_VERSION"
+        YARN_ORB_VERSION="$NODE_PARAM_YARN_VERSION"
+        echo "Selected version of Yarn is $YARN_ORB_VERSION"
     fi
 }
 
 installation_check () {
     echo "Checking if YARN is already installed..."
     if command -v yarn > /dev/null 2>&1; then
-    if yarn --version | grep "$YARN_ORB_VERSION" > /dev/null 2>&1; then
-        echo "Yarn $YARN_ORB_VERSION is already installed"
-        exit 0
-    else
-        echo "A different version of Yarn is installed ($(yarn --version)); removing it"
+        if yarn --version | grep "$YARN_ORB_VERSION" > /dev/null 2>&1; then
+            echo "Yarn $YARN_ORB_VERSION is already installed"
+            exit 0
+        else
+            echo "A different version of Yarn is installed ($(yarn --version)); removing it"
 
-        if uname -a | grep Darwin > /dev/null 2>&1; then
-        brew uninstall yarn > /dev/null 2>&1
-        elif grep Alpine /etc/issue > /dev/null 2>&1; then
-        apk del yarn > /dev/null 2>&1
-        elif grep Debian /etc/issue > /dev/null 2>&1; then
-        $SUDO apt-get remove yarn > /dev/null 2>&1 && \
-            $SUDO apt-get purge yarn > /dev/null 2>&1
-        elif grep Ubuntu /etc/issue > /dev/null 2>&1; then
-        $SUDO apt-get remove yarn > /dev/null 2>&1 && \
-            $SUDO apt-get purge yarn > /dev/null 2>&1
-        elif command -v yum > /dev/null 2>&1; then
-        yum remove yarn > /dev/null 2>&1
+            if uname -a | grep Darwin > /dev/null 2>&1; then
+                brew uninstall yarn > /dev/null 2>&1
+            elif grep Alpine /etc/issue > /dev/null 2>&1; then
+                apk del yarn > /dev/null 2>&1
+            elif grep Debian /etc/issue > /dev/null 2>&1; then
+                $SUDO apt-get remove yarn > /dev/null 2>&1 && \
+                $SUDO apt-get purge yarn > /dev/null 2>&1
+            elif grep Ubuntu /etc/issue > /dev/null 2>&1; then
+                $SUDO apt-get remove yarn > /dev/null 2>&1 && \
+                $SUDO apt-get purge yarn > /dev/null 2>&1
+            elif command -v yum > /dev/null 2>&1; then
+                yum remove yarn > /dev/null 2>&1
+            fi
+
+            $SUDO rm -rf "$HOME/.yarn" > /dev/null 2>&1
+            $SUDO rm -f /usr/local/bin/yarn /usr/local/bin/yarnpkg > /dev/null 2>&1
         fi
-
-        $SUDO rm -rf "$HOME/.yarn" > /dev/null 2>&1
-        $SUDO rm -f /usr/local/bin/yarn /usr/local/bin/yarnpkg > /dev/null 2>&1
-    fi
     fi
 }
 

--- a/src/scripts/install-yarn.sh
+++ b/src/scripts/install-yarn.sh
@@ -30,12 +30,12 @@ installation_check () {
                 $SUDO apt-get remove yarn > /dev/null 2>&1 && \
                 $SUDO apt-get purge yarn > /dev/null 2>&1
                 OLD_YARN=$(which yarn)
-                rm $OLD_YARN
+                rm "$OLD_YARN"
             elif grep Ubuntu /etc/issue > /dev/null 2>&1; then
                 $SUDO apt-get remove yarn > /dev/null 2>&1 && \
                 $SUDO apt-get purge yarn > /dev/null 2>&1
                 OLD_YARN=$(which yarn)
-                rm $OLD_YARN
+                rm "$OLD_YARN"
             elif command -v yum > /dev/null 2>&1; then
                 yum remove yarn > /dev/null 2>&1
             fi


### PR DESCRIPTION
As indicated in #212 the yarn install command fails on machine executors as the old version of yarn is not correctly uninstalled. In these machines, yarn was installed via nvm, so the binary has to be manually removed.
I'm also updating the indentation of this script file.