### PR TITLE
Fix: nocache npm ci

### DIFF
--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -58,7 +58,16 @@ steps:
           command: <<include(scripts/packages/find-package.sh)>>
 
     - when:
-          condition: << parameters.with-cache >>
+          condition: 
+            and:
+            - << parameters.with-cache >>
+            - or:
+                - not:
+                    equal: [npm, << parameters.pkg-manager >>]
+                - and:
+                    - << parameters.override-ci-command >>
+                    - not:
+                        equal: ["npm-ci", << parameters.override-ci-command >>]
           steps:
               - run:
                     working_directory: <<parameters.app-dir>>

--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -11,7 +11,9 @@ parameters:
     with-cache:
         type: boolean
         default: true
-        description: Cache your node packages automatically for faster install times.
+        description: |
+            Cache your node packages automatically for faster install times.
+            Cache will be ignored when using npm ci.
     check-cache:
         type: enum
         default: 'never'
@@ -28,11 +30,13 @@ parameters:
         description: |
             By default, packages will be installed with "npm ci", "yarn install --frozen-lockfile", "yarn install --immutable" or "pnpm install --frozen-lockfile".
             Optionally supply a custom package installation command, with any additional flags needed.
+            When the command npm ci is used, no cache will be used, as the command doesn't benefit from it.
         type: string
         default: ''
     cache-path:
         description: |
             By default, this orb will utilize 'npm ci' and cache the '~/.npm' directory. Override which path to cache with this parameter.
+            The cache will be ignored when using npm ci, as the command doesn't benefit from cache.
         type: string
         default: ''
     cache-only-lockfile:
@@ -58,7 +62,7 @@ steps:
           command: <<include(scripts/packages/find-package.sh)>>
 
     - when:
-          condition: 
+          condition:
             and:
             - << parameters.with-cache >>
             - or:

--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -84,7 +84,12 @@ steps:
                     command: <<include(scripts/packages/npm-install.sh)>>
 
               - when: # cache enabled, save cache
-                    condition: << parameters.with-cache >>
+                    condition:
+                        and:
+                        - << parameters.with-cache >>
+                        - << parameters.override-ci-command >>
+                        - not:
+                            equal: ["npm-ci", << parameters.override-ci-command >>]
                     steps:
                         - when: # custom cache path selected
                               condition: << parameters.cache-path >>

--- a/src/scripts/packages/npm-install.sh
+++ b/src/scripts/packages/npm-install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Configure npm cache path if provided
-if [[ -n "$PARAM_CACHE_PATH" ]]; then
+if [[ -n "$PARAM_CACHE_PATH" ]] && [[ "$PARAM_OVERRIDE_COMMAND" != "npm ci" ]] && [[ -n "$PARAM_OVERRIDE_COMMAND" ]]; then
     npm config set cache "$PARAM_CACHE_PATH"
 fi
 


### PR DESCRIPTION
As pointed out in #202 when npm ci command is used to install dependencies, the cache is ignored. I'm adding some conditions in the command and the script to ignore the cache whenever the npm ci command is used. I'm also adding some extra descriptions in the parameters to inform the users that cache won't be used when the npm ci command is used.