### PR TITLE
Add an option to save nvm cache on installation

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -40,7 +40,7 @@ jobs:
           node-version: "16.13"
           install-yarn: true # Test the install of YARN
           yarn-version: "1.22.5"
-          # nvm-cache-key: v1-<<parameters.os>>
+          nvm-cache-key: v2-<<parameters.os>>
       - run:
           command: |
             if ! node --version | grep -q "16"; then
@@ -57,7 +57,7 @@ jobs:
       - node/install:
           install-pnpm: true # Test the install of PNPM
           pnpm-version: "9.7.1"
-          # nvm-cache-key: v1-lts-<<parameters.os>>
+          nvm-cache-key: v2-lts-<<parameters.os>>
       - run:
           command: |
             if ! pnpm --version | grep -q "9.7.1"; then
@@ -78,7 +78,7 @@ jobs:
       - checkout
       - node/install:
           node-version: "latest"
-          # nvm-cache-key: v1-latest-<<parameters.os>>
+          nvm-cache-key: v2-latest-<<parameters.os>>
       - run:
           name: Check that latest Node.js is installed.
           command: |

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -40,7 +40,7 @@ jobs:
           node-version: "16.13"
           install-yarn: true # Test the install of YARN
           yarn-version: "1.22.5"
-          nvm-cache-key: v1-<<parameters.os>>
+          # nvm-cache-key: v1-<<parameters.os>>
       - run:
           command: |
             if ! node --version | grep -q "16"; then
@@ -57,7 +57,7 @@ jobs:
       - node/install:
           install-pnpm: true # Test the install of PNPM
           pnpm-version: "9.7.1"
-          nvm-cache-key: v1-lts-<<parameters.os>>
+          # nvm-cache-key: v1-lts-<<parameters.os>>
       - run:
           command: |
             if ! pnpm --version | grep -q "9.7.1"; then
@@ -78,7 +78,7 @@ jobs:
       - checkout
       - node/install:
           node-version: "latest"
-          nvm-cache-key: v1-latest-<<parameters.os>>
+          # nvm-cache-key: v1-latest-<<parameters.os>>
       - run:
           name: Check that latest Node.js is installed.
           command: |

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -40,7 +40,7 @@ jobs:
           node-version: "16.13"
           install-yarn: true # Test the install of YARN
           yarn-version: "1.22.5"
-          nvm-cache-key: v3-<<parameters.os>>
+          nvm-cache-key: v2-<<parameters.os>>
       - run:
           command: |
             if ! node --version | grep -q "16"; then
@@ -57,7 +57,7 @@ jobs:
       - node/install:
           install-pnpm: true # Test the install of PNPM
           pnpm-version: "9.7.1"
-          nvm-cache-key: v3-lts-<<parameters.os>>
+          nvm-cache-key: v2-lts-<<parameters.os>>
       - run:
           command: |
             if ! pnpm --version | grep -q "9.7.1"; then
@@ -78,7 +78,7 @@ jobs:
       - checkout
       - node/install:
           node-version: "latest"
-          nvm-cache-key: v3-latest-<<parameters.os>>
+          nvm-cache-key: v2-latest-<<parameters.os>>
       - run:
           name: Check that latest Node.js is installed.
           command: |

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -40,6 +40,7 @@ jobs:
           node-version: "16.13"
           install-yarn: true # Test the install of YARN
           yarn-version: "1.22.5"
+          nvm-cache-key: v1-<<parameters.os>>
       - run:
           command: |
             if ! node --version | grep -q "16"; then
@@ -56,6 +57,7 @@ jobs:
       - node/install:
           install-pnpm: true # Test the install of PNPM
           pnpm-version: "9.7.1"
+          nvm-cache-key: v1-lts-<<parameters.os>>
       - run:
           command: |
             if ! pnpm --version | grep -q "9.7.1"; then
@@ -76,6 +78,7 @@ jobs:
       - checkout
       - node/install:
           node-version: "latest"
+          nvm-cache-key: v1-latest-<<parameters.os>>
       - run:
           name: Check that latest Node.js is installed.
           command: |

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -40,7 +40,7 @@ jobs:
           node-version: "16.13"
           install-yarn: true # Test the install of YARN
           yarn-version: "1.22.5"
-          nvm-cache-key: v2-<<parameters.os>>
+          nvm-cache-key: v3-<<parameters.os>>
       - run:
           command: |
             if ! node --version | grep -q "16"; then
@@ -57,7 +57,7 @@ jobs:
       - node/install:
           install-pnpm: true # Test the install of PNPM
           pnpm-version: "9.7.1"
-          nvm-cache-key: v2-lts-<<parameters.os>>
+          nvm-cache-key: v3-lts-<<parameters.os>>
       - run:
           command: |
             if ! pnpm --version | grep -q "9.7.1"; then
@@ -78,7 +78,7 @@ jobs:
       - checkout
       - node/install:
           node-version: "latest"
-          nvm-cache-key: v2-latest-<<parameters.os>>
+          nvm-cache-key: v3-latest-<<parameters.os>>
       - run:
           name: Check that latest Node.js is installed.
           command: |

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -50,7 +50,7 @@ parameters:
             Defaults to true.
     nvm-cache-key:
         type: string
-        default: nvm-v1
+        default: nvm-v1-<<parameters.node-version>>-
         description: >
             Cache key to use when downloading nodejs.
             This is only used when use-nvm-cache is set to true.

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -76,6 +76,7 @@ steps:
                 key: <<parameters.nvm-cache-key>>
                 paths:
                 - ~/.nvm/.cache
+                - /opt/circleci/.nvm/.cache
     - when:
         condition: <<parameters.install-pnpm>>
         steps:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -76,8 +76,7 @@ steps:
                 name: Save Nvm Cache
                 key: <<parameters.nvm-cache-key>>-<<parameters.node-version>>
                 paths:
-                - ~/.nvm/.cache
-                - /opt/circleci/.nvm/.cache
+                - ${NVM_DIR}/.nvm/.cache
     - when:
         condition: <<parameters.install-pnpm>>
         steps:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -50,11 +50,12 @@ parameters:
             Defaults to true.
     nvm-cache-key:
         type: string
-        default: nvm-v1-<<parameters.node-version>>-
+        default: nvm-v1-cache
         description: >
             Cache key to use when downloading nodejs.
             This is only used when use-nvm-cache is set to true.
-            Defaults to v1, update this value if you need to restart the cache.
+            Defaults to nvm-v1-cache-<node-version>, update this value if you need to restart the cache.
+            If you are using multiple executors, add the executor as part of the key.
 steps:
     - when:
         condition: <<parameters.use-nvm-cache>>
@@ -62,7 +63,7 @@ steps:
             - restore_cache:
                 name: Restore Nvm Cache
                 keys:
-                - <<parameters.nvm-cache-key>>
+                - <<parameters.nvm-cache-key>>-<<parameters.node-version>>
     - run:
         name: Install Node.js <<parameters.node-version>>
         environment:
@@ -73,7 +74,7 @@ steps:
         steps:
             - save_cache:
                 name: Save Nvm Cache
-                key: <<parameters.nvm-cache-key>>
+                key: <<parameters.nvm-cache-key>>-<<parameters.node-version>>
                 paths:
                 - ~/.nvm/.cache
                 - /opt/circleci/.nvm/.cache

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -76,7 +76,8 @@ steps:
                 name: Save Nvm Cache
                 key: <<parameters.nvm-cache-key>>-<<parameters.node-version>>
                 paths:
-                - ${NVM_DIR}/.nvm/.cache
+                - ~/.nvm/.cache
+                - /opt/circleci/.nvm/.cache
     - when:
         condition: <<parameters.install-pnpm>>
         steps:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -50,7 +50,7 @@ parameters:
             Defaults to true.
     nvm-cache-key:
         type: string
-        default: v1
+        default: nvm-cache-v1
         description: >
             Cache key to use when downloading nodejs.
             This is only used when use-nvm-cache is set to true.

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -54,7 +54,8 @@ parameters:
         description: >
             Cache key to use when downloading nodejs.
             This is only used when use-nvm-cache is set to true.
-            Defaults to nvm-v1-cache-<node-version>, update this value if you need to restart the cache.
+            Defaults to nvm-v1-cache, update this value if you need to restart the cache.
+            The node-version is added by default at the end of the cache key.
             If you are using multiple executors, add the executor as part of the key.
 steps:
     - when:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -61,7 +61,7 @@ steps:
         steps:
         - restore_cache:
             name: Restore Nvm Cache
-            keys: 
+            keys:
             - <<parameters.nvm-cache-key>>
     - run:
         name: Install Node.js <<parameters.node-version>>

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -50,7 +50,7 @@ parameters:
             Defaults to true.
     nvm-cache-key:
         type: string
-        default: nvm-cache-v1
+        default: nvm-v1
         description: >
             Cache key to use when downloading nodejs.
             This is only used when use-nvm-cache is set to true.
@@ -75,7 +75,7 @@ steps:
                 name: Save Nvm Cache
                 key: <<parameters.nvm-cache-key>>
                 paths:
-                - /opt/circleci/.nvm/.cache
+                - ~/.nvm/.cache
     - when:
         condition: <<parameters.install-pnpm>>
         steps:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -59,10 +59,10 @@ steps:
     - when:
         condition: <<parameters.use-nvm-cache>>
         steps:
-        - restore_cache:
-            name: Restore Nvm Cache
-            keys:
-            - <<parameters.nvm-cache-key>>
+            - restore_cache:
+                name: Restore Nvm Cache
+                keys:
+                - <<parameters.nvm-cache-key>>
     - run:
         name: Install Node.js <<parameters.node-version>>
         environment:
@@ -71,11 +71,11 @@ steps:
     - when:
         condition: <<parameters.use-nvm-cache>>
         steps:
-        - save_cache:
-            name: Save Nvm Cache
-            keys: <<parameters.nvm-cache-key>>
-            paths:
-            - /opt/circleci/.nvm/.cache
+            - save_cache:
+                name: Save Nvm Cache
+                keys: <<parameters.nvm-cache-key>>
+                paths:
+                - /opt/circleci/.nvm/.cache
     - when:
         condition: <<parameters.install-pnpm>>
         steps:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -41,14 +41,41 @@ parameters:
             Pick a version of Yarn to install (if no version is specified,
             the latest stable version will be installed):
             https://github.com/yarnpkg/yarn/releases
-
+    use-nvm-cache:
+        type: boolean
+        default: true
+        description: >
+            Indicates if cache would be used when installing nodejs,
+            this would reduce the amount of errors when downloading the binaries.
+            Defaults to true.
+    nvm-cache-key:
+        type: string
+        default: v1
+        description: >
+            Cache key to use when downloading nodejs.
+            This is only used when use-nvm-cache is set to true.
+            Defaults to v1, update this value if you need to restart the cache.
 steps:
+    - when:
+        condition: <<parameters.use-nvm-cache>>
+        steps:
+        - restore_cache:
+            name: Restore Nvm Cache
+            keys: 
+            - <<parameters.nvm-cache-key>>
     - run:
         name: Install Node.js <<parameters.node-version>>
         environment:
             NODE_PARAM_VERSION: <<parameters.node-version>>
         command: <<include(scripts/install-nvm.sh)>>
-
+    - when:
+        condition: <<parameters.use-nvm-cache>>
+        steps:
+        - save_cache:
+            name: Save Nvm Cache
+            keys: <<parameters.nvm-cache-key>>
+            paths:
+            - /opt/circleci/.nvm/.cache
     - when:
         condition: <<parameters.install-pnpm>>
         steps:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -73,7 +73,7 @@ steps:
         steps:
             - save_cache:
                 name: Save Nvm Cache
-                keys: <<parameters.nvm-cache-key>>
+                key: <<parameters.nvm-cache-key>>
                 paths:
                 - /opt/circleci/.nvm/.cache
     - when:


### PR DESCRIPTION
There have been many reports from failures when installing an specific node version at the momento of downloading the binary. I'm adding a new parameter that allows to store the .nvm/.cache folder so the installation can use it instead of downloading every time.