### PR TITLE
Add alternative way to enable corepack

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -184,6 +184,20 @@ jobs:
   integration-test-yarn-berry:
     environment:
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
+    docker:
+    - image: cypress/browsers
+    steps:
+      - checkout
+      - run: mv ~/project/sample/package-berry.json ~/project/sample/package.json
+      - node/install-packages:
+          pkg-manager: yarn-berry
+          cache-version: yarn-berry-v2
+          app-dir: "~/project/sample"
+          override-ci-command: yarn install
+      - run: cd ~/project/sample && yarn test
+  integration-test-yarn-berry-nocimg:
+    environment:
+      YARN_ENABLE_IMMUTABLE_INSTALLS: false
     executor:
       name: node/default
     steps:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -181,7 +181,7 @@ jobs:
           app-dir: "~/project/sample"
       - run: yarn --version
       - run: cd ~/project/sample && yarn test
-  integration-test-yarn-berry:
+  integration-test-yarn-berry-nocimg:
     environment:
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
     docker:
@@ -195,7 +195,7 @@ jobs:
           app-dir: "~/project/sample"
           override-ci-command: yarn install
       - run: cd ~/project/sample && yarn test
-  integration-test-yarn-berry-nocimg:
+  integration-test-yarn-berry:
     environment:
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
     executor:
@@ -412,6 +412,8 @@ workflows:
       - integration-test-yarn:
           filters: *filters
       - integration-test-yarn-berry:
+          filters: *filters
+      - integration-test-yarn-berry-nocimg:
           filters: *filters
       - orb-tools/pack:
           filters: *release-filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -238,7 +238,7 @@ workflows:
           filters: *filters
           name: node-npm-jest-test-job
           app-dir: "~/project/sample"
-          cache-version: v4
+          cache-version: v1
           test-results-for: jest
           setup:
             - run:
@@ -250,7 +250,7 @@ workflows:
           filters: *filters
           name: node-yarn-jest-test-job
           app-dir: "~/project/sample"
-          cache-version: v4
+          cache-version: v1
           test-results-for: jest
           pkg-manager: yarn
           setup:
@@ -263,7 +263,7 @@ workflows:
           filters: *filters
           name: node-pnpm-jest-test-job
           app-dir: "~/project/sample"
-          cache-version: v4
+          cache-version: v1
           test-results-for: jest
           pkg-manager: pnpm
           setup:
@@ -276,7 +276,7 @@ workflows:
           filters: *filters
           name: node-npm-mocha-test-job
           app-dir: "~/project/sample"
-          cache-version: v4
+          cache-version: v1
           test-results-for: mocha
           run-command: testmocha
           setup:
@@ -289,7 +289,7 @@ workflows:
           filters: *filters
           name: node-yarn-mocha-test-job
           app-dir: "~/project/sample"
-          cache-version: v4
+          cache-version: v1
           test-results-for: mocha
           pkg-manager: yarn
           run-command: testmocha
@@ -303,7 +303,7 @@ workflows:
           filters: *filters
           name: node-pnpm-mocha-test-job
           app-dir: "~/project/sample"
-          cache-version: v4
+          cache-version: v1
           test-results-for: mocha
           pkg-manager: pnpm
           run-command: testmocha
@@ -317,7 +317,7 @@ workflows:
           filters: *filters
           name: node-yarn-mocha-with-test-result-path-job
           app-dir: "~/project/sample"
-          cache-version: v4
+          cache-version: v1
           test-results-for: mocha
           pkg-manager: yarn
           run-command: testmocha
@@ -332,7 +332,7 @@ workflows:
           filters: *filters
           name: node-test-results-file-job
           app-dir: "~/project/sample"
-          cache-version: v4
+          cache-version: v1
           test-results-path: sample/other-junit.xml
           setup:
             - run:
@@ -344,7 +344,7 @@ workflows:
           filters: *filters
           name: node-test-no-junit
           app-dir: "~/project/sample"
-          cache-version: v4
+          cache-version: v1
           setup:
             - run:
                 name: Remove other lock files
@@ -355,14 +355,14 @@ workflows:
           filters: *filters
           name: node-test-with-coverage
           app-dir: "~/project/sample"
-          cache-version: v4
+          cache-version: v1
           run-command: "test:coverage"
           test-coverage-path: ~/project/sample/coverage
       - node/run:
           filters: *filters
           name: node-run-npm-job
           app-dir: "~/project/sample"
-          cache-version: v4
+          cache-version: v1
           npm-run: build
           setup:
             - run:
@@ -387,7 +387,7 @@ workflows:
           filters: *filters
           name: node-run-upload-artifacts
           app-dir: "~/project/sample"
-          cache-version: v4
+          cache-version: v1
           npm-run: build
           artifacts-path: "~/project/sample/dist"
       - node/run:

--- a/src/scripts/packages/yarn-berry-install.sh
+++ b/src/scripts/packages/yarn-berry-install.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-corepack enable --install-directory ~/bin
+if ! corepack enable; then
+    echo "Using alternative corepack location"
+    corepack enable --install-directory ~/bin
+fi
 # Run override ci command if provided, otherwise run default yarn install
 # See: https://yarnpkg.com/configuration/yarnrc/#cacheFolder
 if [[ -n "$PARAM_CACHE_PATH" ]]; then


### PR DESCRIPTION
resolves #231 

Previously corepack was installed in the ~/bin as the circleci images have problems with the default directory.
I'm adding a default command to use the default location, and an alternative command to install in ~/bin when the other fails.

I'm adding a new test to validate the run on cimg image and non cimg image.