### PR TITLE
Add cache parameters to jobs

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -423,6 +423,11 @@ workflows:
           pub_type: production
           requires:
             - orb-tools/pack
+            - integration-test-override-ci-windows
+            - integration-test-override-ci
+            - integration-test-yarn
+            - integration-test-yarn-berry
+            - integration-test-yarn-berry-nocimg
             - integration-test-install-specified-version
             - integration-test-install-latest
             - integration-test-install-lts
@@ -430,8 +435,15 @@ workflows:
             - integration-test-pnpm
             - integration-test-reinstall-yarn
             - node-yarn-mocha-with-test-result-path-job
+            - node-yarn-mocha-test-job
+            - node-yarn-jest-test-job
             - node-test-results-file-job
+            - node-npm-jest-test-job
+            - node-test-with-coverage
             - node-run-npm-job
+            - node-pnpm-mocha-test-job
+            - node-test-no-junit
+            - node-pnpm-jest-test-job
             - node-run-yarn-job
             - node-run-pnpm-job
             - node-run-upload-artifacts

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -59,7 +59,37 @@ parameters:
         - 2xlarge
         - 2xlarge+
         type: enum
-
+    include-branch-in-cache-key:
+        type: boolean
+        default: true
+        description: >
+            If true, this cache bucket will only apply to jobs within the same branch.
+    cache-path:
+        description: |
+            By default, this orb will utilize 'npm ci' and cache the '~/.npm' directory. Override which path to cache with this parameter.
+            The cache will be ignored when using npm ci, as the command doesn't benefit from cache.
+        type: string
+        default: ''
+    cache-only-lockfile:
+        type: boolean
+        default: true
+        description: |
+            If true, package.json will be ignored in the cache key. Useful for projects where package.json changes do not always invalidate dependencies.
+            Note: package.json will still be the final fallback key incase a project is not configured with a lock file.
+    with-cache:
+        type: boolean
+        default: true
+        description: |
+            Cache your node packages automatically for faster install times.
+            Cache will be ignored when using npm ci.
+    check-cache:
+        type: enum
+        default: 'never'
+        enum: ['never', 'always', 'detect']
+        description: |
+            Yarn berry only for Zero install support -
+            Use 'always' to always --check-cache argument to yarn install.
+            Use 'detect' to enable caching of yarn.lock and to only add when required.
 executor:
     name: default
     tag: << parameters.version >>
@@ -73,6 +103,11 @@ steps:
           pkg-manager: <<parameters.pkg-manager>>
           cache-version: <<parameters.cache-version>>
           override-ci-command: <<parameters.override-ci-command>>
+          include-branch-in-cache-key: <<parameters.include-branch-in-cache-key>>
+          cache-path: <<parameters.cache-path>>
+          cache-only-lockfile: <<parameters.cache-only-lockfile>>
+          with-cache: <<parameters.with-cache>>
+          check-cache: <<parameters.check-cache>>
     - run:
           name: Run <<parameters.pkg-manager>> <<parameters.npm-run>>
           working_directory: <<parameters.app-dir>>

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -66,7 +66,37 @@ parameters:
         - 2xlarge
         - 2xlarge+
         type: enum
-
+    include-branch-in-cache-key:
+        type: boolean
+        default: true
+        description: >
+            If true, this cache bucket will only apply to jobs within the same branch.
+    cache-path:
+        description: |
+            By default, this orb will utilize 'npm ci' and cache the '~/.npm' directory. Override which path to cache with this parameter.
+            The cache will be ignored when using npm ci, as the command doesn't benefit from cache.
+        type: string
+        default: ''
+    cache-only-lockfile:
+        type: boolean
+        default: true
+        description: |
+            If true, package.json will be ignored in the cache key. Useful for projects where package.json changes do not always invalidate dependencies.
+            Note: package.json will still be the final fallback key incase a project is not configured with a lock file.
+    with-cache:
+        type: boolean
+        default: true
+        description: |
+            Cache your node packages automatically for faster install times.
+            Cache will be ignored when using npm ci.
+    check-cache:
+        type: enum
+        default: 'never'
+        enum: ['never', 'always', 'detect']
+        description: |
+            Yarn berry only for Zero install support -
+            Use 'always' to always --check-cache argument to yarn install.
+            Use 'detect' to enable caching of yarn.lock and to only add when required.
 executor:
     name: default
     tag: << parameters.version >>
@@ -80,6 +110,11 @@ steps:
           pkg-manager: <<parameters.pkg-manager>>
           cache-version: <<parameters.cache-version>>
           override-ci-command: <<parameters.override-ci-command>>
+          include-branch-in-cache-key: <<parameters.include-branch-in-cache-key>>
+          cache-path: <<parameters.cache-path>>
+          cache-only-lockfile: <<parameters.cache-only-lockfile>>
+          with-cache: <<parameters.with-cache>>
+          check-cache: <<parameters.check-cache>>
     - when: # Run tests for NPM, without test results
           condition:
               and:


### PR DESCRIPTION
Resolves #161 

The job run and test are using the defaults for most of the cache parameters in the install-packages command. I'm adding the parameters to these jobs as well, so they can be used with a better level of configuration.

I'm also fixing the requisites in the tests so the deploy cannot run without all the tests passing.